### PR TITLE
fix: slippageTolerance take percentage sting instead

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,7 +2,7 @@ import { BigNumber } from 'ethers';
 
 export const DEFAULT_AUCTION_PERIOD_SECS = 60;
 export const DEFAULT_EXCLUSIVE_PERIOD_SECS = 16;
-export const DEFAULT_SLIPPAGE_TOLERANCE = '5'; // 0.5%
-export const THOUSAND_FIXED_POINT = BigNumber.from('1000');
+export const DEFAULT_SLIPPAGE_TOLERANCE = '0.5'; // 0.5%
+export const HUNDRED_PERCENT = BigNumber.from(100_00); // 100.00%
 export const DUMMY_GAS_WEI = '100';
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';

--- a/lib/entities/quote/DutchLimitQuote.ts
+++ b/lib/entities/quote/DutchLimitQuote.ts
@@ -2,9 +2,9 @@ import { DutchLimitOrderBuilder, DutchLimitOrderInfoJSON } from '@uniswap/gouda-
 import { TradeType } from '@uniswap/sdk-core';
 import { BigNumber } from 'ethers';
 
-import { THOUSAND_FIXED_POINT } from '../../constants';
-import { DutchLimitRequest, RoutingType } from '..';
 import { Quote, QuoteJSON } from '.';
+import { DutchLimitRequest, RoutingType } from '..';
+import { HUNDRED_PERCENT } from '../../constants';
 import { ClassicQuote } from './ClassicQuote';
 
 export type DutchLimitQuoteJSON = {
@@ -20,8 +20,8 @@ export type DutchLimitQuoteJSON = {
 
 export class DutchLimitQuote implements Quote {
   public routingType: RoutingType.DUTCH_LIMIT = RoutingType.DUTCH_LIMIT;
-  public static improvementExactIn = BigNumber.from(1010);
-  public static improvementExactOut = BigNumber.from(990);
+  public static improvementExactIn = BigNumber.from(10100);
+  public static improvementExactOut = BigNumber.from(9900);
 
   public static fromResponseBody(request: DutchLimitRequest, body: DutchLimitQuoteJSON): DutchLimitQuote {
     return new DutchLimitQuote(
@@ -58,7 +58,7 @@ export class DutchLimitQuote implements Quote {
         request.info.tokenIn,
         request.info.amount, // fixed amountIn
         quote.request.info.tokenOut,
-        quote.amountOut.mul(DutchLimitQuote.improvementExactIn).div(THOUSAND_FIXED_POINT),
+        quote.amountOut.mul(DutchLimitQuote.improvementExactIn).div(HUNDRED_PERCENT),
         request.config.offerer,
         ''
       );
@@ -68,7 +68,7 @@ export class DutchLimitQuote implements Quote {
         request.info.tokenInChainId,
         request.info.requestId,
         request.info.tokenIn,
-        quote.amountIn.mul(DutchLimitQuote.improvementExactOut).div(THOUSAND_FIXED_POINT),
+        quote.amountIn.mul(DutchLimitQuote.improvementExactOut).div(HUNDRED_PERCENT),
         quote.request.info.tokenOut,
         request.info.amount, // fixed amountOut
         request.config.offerer,
@@ -86,7 +86,7 @@ export class DutchLimitQuote implements Quote {
         this.tokenIn,
         this.amountIn,
         quote.request.info.tokenOut,
-        quote.amountOut.mul(DutchLimitQuote.improvementExactIn).div(THOUSAND_FIXED_POINT),
+        quote.amountOut.mul(DutchLimitQuote.improvementExactIn).div(HUNDRED_PERCENT),
         this.offerer,
         ''
       );
@@ -96,7 +96,7 @@ export class DutchLimitQuote implements Quote {
         this.chainId,
         this.requestId,
         this.tokenIn,
-        quote.amountIn.mul(DutchLimitQuote.improvementExactOut).div(THOUSAND_FIXED_POINT),
+        quote.amountIn.mul(DutchLimitQuote.improvementExactOut).div(HUNDRED_PERCENT),
         quote.request.info.tokenOut,
         this.amountOut,
         this.offerer,
@@ -143,12 +143,12 @@ export class DutchLimitQuote implements Quote {
   private calculateEndAmountFromSlippage(): BigNumber {
     if (this.request.info.type === TradeType.EXACT_INPUT) {
       return this.amountOut
-        .mul(THOUSAND_FIXED_POINT.sub(BigNumber.from(this.request.info.slippageTolerance)))
-        .div(THOUSAND_FIXED_POINT);
+        .mul(HUNDRED_PERCENT.sub(BigNumber.from(this.request.info.slippageTolerance)))
+        .div(HUNDRED_PERCENT);
     } else {
       return this.amountIn
-        .mul(THOUSAND_FIXED_POINT.add(BigNumber.from(this.request.info.slippageTolerance)))
-        .div(THOUSAND_FIXED_POINT);
+        .mul(HUNDRED_PERCENT.add(BigNumber.from(this.request.info.slippageTolerance)))
+        .div(HUNDRED_PERCENT);
     }
   }
 }

--- a/lib/entities/request/ClassicRequest.ts
+++ b/lib/entities/request/ClassicRequest.ts
@@ -1,8 +1,8 @@
 import { Protocol } from '@uniswap/router-sdk';
 import { BigNumber } from 'ethers';
 
-import { DUMMY_GAS_WEI } from '../../constants';
 import { QuoteRequest, QuoteRequestInfo, RoutingType } from '.';
+import { DUMMY_GAS_WEI } from '../../constants';
 
 export interface ClassicConfig {
   protocols: Protocol[];
@@ -41,6 +41,7 @@ export class ClassicRequest implements QuoteRequest {
             return [];
           }
         }),
+        slippageTolerance: body.slippageTolerance,
         gasPriceWei: body.gasPriceWei ?? DUMMY_GAS_WEI,
         permitAmount: body.permitAmount ? BigNumber.from(body.permitAmount) : undefined,
       })

--- a/lib/entities/request/DutchLimitRequest.ts
+++ b/lib/entities/request/DutchLimitRequest.ts
@@ -1,5 +1,10 @@
-import { DEFAULT_AUCTION_PERIOD_SECS, DEFAULT_EXCLUSIVE_PERIOD_SECS, ZERO_ADDRESS } from '../../constants';
 import { QuoteRequest, QuoteRequestInfo, RoutingType } from '.';
+import {
+  DEFAULT_AUCTION_PERIOD_SECS,
+  DEFAULT_EXCLUSIVE_PERIOD_SECS,
+  DEFAULT_SLIPPAGE_TOLERANCE,
+  ZERO_ADDRESS,
+} from '../../constants';
 
 export * from './ClassicRequest';
 export * from './DutchLimitRequest';
@@ -18,11 +23,18 @@ export class DutchLimitRequest implements QuoteRequest {
   public routingType: RoutingType.DUTCH_LIMIT = RoutingType.DUTCH_LIMIT;
 
   public static fromRequestBody(info: QuoteRequestInfo, body: DutchLimitConfigJSON): DutchLimitRequest {
-    return new DutchLimitRequest(info, {
-      offerer: body.offerer ?? ZERO_ADDRESS,
-      exclusivePeriodSecs: body.exclusivePeriodSecs ?? DEFAULT_EXCLUSIVE_PERIOD_SECS,
-      auctionPeriodSecs: body.auctionPeriodSecs ?? DEFAULT_AUCTION_PERIOD_SECS,
-    });
+    const convertedSlippage = (parseFloat(info.slippageTolerance ?? DEFAULT_SLIPPAGE_TOLERANCE) * 100).toString();
+    return new DutchLimitRequest(
+      {
+        ...info,
+        slippageTolerance: convertedSlippage,
+      },
+      {
+        offerer: body.offerer ?? ZERO_ADDRESS,
+        exclusivePeriodSecs: body.exclusivePeriodSecs ?? DEFAULT_EXCLUSIVE_PERIOD_SECS,
+        auctionPeriodSecs: body.auctionPeriodSecs ?? DEFAULT_AUCTION_PERIOD_SECS,
+      }
+    );
   }
 
   constructor(public readonly info: QuoteRequestInfo, public readonly config: DutchLimitConfig) {}

--- a/lib/providers/transformers/SyntheticUniswapXTransformer.ts
+++ b/lib/providers/transformers/SyntheticUniswapXTransformer.ts
@@ -1,10 +1,10 @@
 import Logger from 'bunyan';
 
+import { QuoteTransformer } from '.';
 import { DutchLimitQuote, Quote, QuoteRequest } from '../../entities';
 import { ClassicQuote } from '../../entities/quote/ClassicQuote';
 import { DutchLimitRequest } from '../../entities/request/DutchLimitRequest';
 import { RoutingType } from '../../entities/request/index';
-import { QuoteTransformer } from '.';
 
 export class SyntheticUniswapXTransformer implements QuoteTransformer {
   private log: Logger;

--- a/lib/util/validator.ts
+++ b/lib/util/validator.ts
@@ -52,7 +52,7 @@ export class FieldValidator {
 
   public static readonly enableUniversalRouter = Joi.boolean();
 
-  public static readonly slippageTolerance = Joi.number().min(0).max(200); // 20% in 1000 FIXED POINT
+  public static readonly slippageTolerance = Joi.number().min(0).max(20); // 20%
 
   public static readonly deadline = Joi.number().greater(0).max(10800); // 180 mins, same as interface max;
 

--- a/test/providers/transformers/SyntheticUniswapXTransformer.test.ts
+++ b/test/providers/transformers/SyntheticUniswapXTransformer.test.ts
@@ -1,6 +1,6 @@
 import Logger from 'bunyan';
 
-import { THOUSAND_FIXED_POINT } from '../../../lib/constants';
+import { HUNDRED_PERCENT } from '../../../lib/constants';
 import { Quote, RoutingType } from '../../../lib/entities';
 import { SyntheticUniswapXTransformer } from '../../../lib/providers/transformers';
 import {
@@ -46,7 +46,7 @@ describe('SyntheticUniswapXTransformer', () => {
       expect(transformed.length).toEqual(3);
 
       const outStartAmount = CLASSIC_QUOTE_EXACT_IN_LARGE.amountOut.mul(101).div(100);
-      const outEndAmount = outStartAmount.mul(THOUSAND_FIXED_POINT.sub(5)).div(THOUSAND_FIXED_POINT);
+      const outEndAmount = outStartAmount.mul(HUNDRED_PERCENT.sub(50)).div(HUNDRED_PERCENT);
       expect(transformed[2].toJSON()).toMatchObject({
         outputs: [
           {
@@ -77,7 +77,7 @@ describe('SyntheticUniswapXTransformer', () => {
       expect(transformed.length).toEqual(3);
 
       const outStartAmount = CLASSIC_QUOTE_EXACT_OUT_LARGE.amountIn.mul(99).div(100);
-      const outEndAmount = outStartAmount.mul(THOUSAND_FIXED_POINT.add(5)).div(THOUSAND_FIXED_POINT);
+      const outEndAmount = outStartAmount.mul(HUNDRED_PERCENT.add(50)).div(HUNDRED_PERCENT);
       expect(transformed[2].toJSON()).toMatchObject({
         input: {
           startAmount: outStartAmount.toString(),


### PR DESCRIPTION
To be consistent with routing-api, URA now takes `slippageTolerance` as percentage string in the quote request instead, i.e. `slippageTolerance?: string = 0.5` corresponds to 0.5% default slippage.
