### PR TITLE
fix: add offerer to request logs and log response for DutchLimit.

### DIFF
--- a/lib/entities/request/index.ts
+++ b/lib/entities/request/index.ts
@@ -72,6 +72,8 @@ export function parseQuoteRequests(body: QuoteRequestBodyJSON, log?: Logger): Qu
     return [];
   });
 
+  const offerer = (requests.find((r) => r.routingType === RoutingType.DUTCH_LIMIT)?.config as DutchLimitConfig)
+    ?.offerer;
   log?.info({
     eventType: 'UnifiedRoutingQuoteRequest',
     body: {
@@ -84,6 +86,8 @@ export function parseQuoteRequests(body: QuoteRequestBodyJSON, log?: Logger): Qu
       type: TradeType[info.type],
       configs: requests.map((r) => r.routingType).join(','),
       createdAt: currentTimestampInSeconds(),
+      // only log offerer if it's a dutch limit request
+      ...(offerer && { offerer: offerer }),
     },
   });
 

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -80,7 +80,8 @@ export class QuoteHandler extends APIGLambdaHandler<
 
     log.info({ quotesTransformed: quotesTransformed }, 'quotesTransformed');
 
-    const bestQuote = await getBestQuote(quotesTransformed, requests.length > 1, log);
+    const uniswapXRequested = requests.filter((request) => request.routingType === RoutingType.DUTCH_LIMIT).length > 0;
+    const bestQuote = await getBestQuote(quotesTransformed, uniswapXRequested, log);
     if (!bestQuote) {
       return {
         statusCode: 404,

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,8 +1,10 @@
+import { getAddress } from 'ethers/lib/utils';
 import { RoutingType } from '../lib/entities';
 
 export const CHAIN_IN_ID = 1;
 export const CHAIN_OUT_ID = 1;
 export const OFFERER = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+export const CHECKSUM_OFFERER = getAddress(OFFERER);
 export const TOKEN_IN = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984';
 export const TOKEN_OUT = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 export const AMOUNT_IN = '1000000000000000000';

--- a/test/unit/lib/handlers/quote/handler.test.ts
+++ b/test/unit/lib/handlers/quote/handler.test.ts
@@ -9,6 +9,7 @@ import { ApiInjector, ApiRInj } from '../../../../../lib/handlers/base';
 import { compareQuotes, getBestQuote, getQuotes, QuoteHandler } from '../../../../../lib/handlers/quote/handler';
 import { ContainerInjected, QuoterByRoutingType } from '../../../../../lib/handlers/quote/injector';
 import { Quoter } from '../../../../../lib/providers/quoters';
+import { CHECKSUM_OFFERER } from '../../../../constants';
 import {
   CLASSIC_QUOTE_EXACT_IN_BETTER,
   CLASSIC_QUOTE_EXACT_IN_WORSE,
@@ -110,6 +111,7 @@ describe('QuoteHandler', () => {
               tokenOut: QUOTE_REQUEST_BODY_MULTI.tokenOut,
               amount: QUOTE_REQUEST_BODY_MULTI.amount,
               type: QUOTE_REQUEST_BODY_MULTI.type,
+              offerer: CHECKSUM_OFFERER,
               configs: 'DUTCH_LIMIT,CLASSIC',
               createdAt: expect.any(String),
             }),


### PR DESCRIPTION
## Summary
- Add `offerer` to the URA request redshift logs.
- Log responses if there are any `DutchLimit` requests instead of checking the length of requests.