### PR TITLE
feat: update exclusivity

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from 'ethers';
 
 export const DEFAULT_AUCTION_PERIOD_SECS = 60;
-export const DEFAULT_EXCLUSIVE_PERIOD_SECS = 16;
 export const DEFAULT_SLIPPAGE_TOLERANCE = '0.5'; // 0.5%
 export const HUNDRED_PERCENT = BigNumber.from(100_00); // 100.00%
 export const NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const WETH_WRAP_GAS = 27938; // 27,938 warm deposit, 45,038 cold deposit
+export const DEFAULT_EXCLUSIVITY_OVERRIDE_BPS = BigNumber.from(30); // non-exclusive fillers must override price by this much

--- a/lib/entities/quote/DutchLimitQuote.ts
+++ b/lib/entities/quote/DutchLimitQuote.ts
@@ -1,4 +1,4 @@
-import { DutchLimitOrderBuilder, DutchLimitOrderInfoJSON, encodeExclusiveFillerData } from '@uniswap/gouda-sdk';
+import { DutchLimitOrderBuilder, DutchLimitOrderInfoJSON } from '@uniswap/gouda-sdk';
 import { TradeType } from '@uniswap/sdk-core';
 import { BigNumber, ethers } from 'ethers';
 
@@ -123,7 +123,7 @@ export class DutchLimitQuote implements Quote {
     const orderBuilder = new DutchLimitOrderBuilder(this.chainId);
     const startTime = Math.floor(Date.now() / 1000);
     const nonce = this.nonce ?? this.generateRandomNonce();
-    const decayStartTime = startTime + this.request.config.exclusivePeriodSecs;
+    const decayStartTime = startTime;
 
     const builder = orderBuilder
       .startTime(decayStartTime)
@@ -144,7 +144,7 @@ export class DutchLimitQuote implements Quote {
       });
 
     if (this.filler) {
-      builder.validation(encodeExclusiveFillerData(this.filler, decayStartTime, this.chainId));
+      builder.exclusiveFiller(this.filler, BigNumber.from(this.request.config.exclusivityOverrideBps));
     }
 
     const order = builder.build();

--- a/lib/entities/request/DutchLimitRequest.ts
+++ b/lib/entities/request/DutchLimitRequest.ts
@@ -1,7 +1,7 @@
 import { QuoteRequest, QuoteRequestInfo, RoutingType } from '.';
 import {
   DEFAULT_AUCTION_PERIOD_SECS,
-  DEFAULT_EXCLUSIVE_PERIOD_SECS,
+  DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
   DEFAULT_SLIPPAGE_TOLERANCE,
   NATIVE_ADDRESS,
 } from '../../constants';
@@ -11,7 +11,7 @@ export * from './DutchLimitRequest';
 
 export interface DutchLimitConfig {
   offerer: string;
-  exclusivePeriodSecs: number;
+  exclusivityOverrideBps: number;
   auctionPeriodSecs: number;
 }
 
@@ -31,7 +31,7 @@ export class DutchLimitRequest implements QuoteRequest {
       },
       {
         offerer: body.offerer ?? NATIVE_ADDRESS,
-        exclusivePeriodSecs: body.exclusivePeriodSecs ?? DEFAULT_EXCLUSIVE_PERIOD_SECS,
+        exclusivityOverrideBps: body.exclusivityOverrideBps ?? DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
         auctionPeriodSecs: body.auctionPeriodSecs ?? DEFAULT_AUCTION_PERIOD_SECS,
       }
     );

--- a/lib/util/validator.ts
+++ b/lib/util/validator.ts
@@ -54,6 +54,8 @@ export class FieldValidator {
 
   public static readonly slippageTolerance = Joi.number().min(0).max(20); // 20%
 
+  public static readonly exclusivityOverrideBps = Joi.number().min(0).max(10000); // 0 to 100%
+
   public static readonly deadline = Joi.number().greater(0).max(10800); // 180 mins, same as interface max;
 
   public static readonly minSplits = Joi.number().max(7);
@@ -86,7 +88,7 @@ export class FieldValidator {
   public static readonly dutchLimitConfig = Joi.object({
     routingType: FieldValidator.routingType.required(),
     offerer: FieldValidator.address.optional(),
-    exclusivePeriodSecs: FieldValidator.positiveNumber.optional(),
+    exclusivityOverrideBps: FieldValidator.positiveNumber.optional(),
     auctionPeriodSecs: FieldValidator.positiveNumber.optional(),
     slippageTolerance: FieldValidator.slippageTolerance.optional(),
   });

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -13,7 +13,7 @@ export const FILLER = '0x0000000000000000000000000000000000000000';
 export const DL_CONFIG = {
   routingType: RoutingType.DUTCH_LIMIT,
   offerer: OFFERER,
-  exclusivePeriodSecs: 24,
+  exclusivityOverrideBps: 24,
   auctionPeriodSecs: 60,
 };
 

--- a/test/integ/quote-classic.test.ts
+++ b/test/integ/quote-classic.test.ts
@@ -1537,8 +1537,7 @@ describe('quote', function () {
 
               if (type == 'EXACT_INPUT') {
                 // We've swapped 10 ETH + gas costs
-                expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('1', Ether.onChain(1)))).to.be
-                  .true;
+                expect(tokenInBefore.subtract(tokenInAfter).greaterThan(parseAmount('1', Ether.onChain(1)))).to.be.true;
                 checkQuoteToken(tokenOutBefore, tokenOutAfter, CurrencyAmount.fromRawAmount(UNI_MAINNET, quote.quote));
               } else {
                 expect(tokenOutAfter.subtract(tokenOutBefore).toExact()).to.equal('100');

--- a/test/providers/transformers/QuoteTransformers/SyntheticUniswapXTransformer.test.ts
+++ b/test/providers/transformers/QuoteTransformers/SyntheticUniswapXTransformer.test.ts
@@ -68,12 +68,12 @@ describe('SyntheticUniswapXTransformer', () => {
       ]);
 
       expect(transformed.length).toEqual(3);
-      
+
       const quoteByRoutingType: QuoteByRoutingType = {};
       transformed.forEach((quote) => (quoteByRoutingType[quote.routingType] = quote));
 
       // No change to the RFQ quote
-      expect(transformed[0].amountOut).toEqual(DL_QUOTE_NATIVE_EXACT_IN_BETTER.amountOut)
+      expect(transformed[0].amountOut).toEqual(DL_QUOTE_NATIVE_EXACT_IN_BETTER.amountOut);
 
       const outStartAmount = applyWETHGasAdjustment(NATIVE_ADDRESS, CLASSIC_QUOTE_EXACT_IN_LARGE_GAS)
         .mul(DutchLimitQuote.improvementExactIn)
@@ -87,7 +87,7 @@ describe('SyntheticUniswapXTransformer', () => {
             endAmount: outEndAmount.toString(),
           },
         ],
-      })
+      });
     });
   });
 

--- a/test/unit/lib/entities/quoteRequest.test.ts
+++ b/test/unit/lib/entities/quoteRequest.test.ts
@@ -4,7 +4,7 @@ import { AMOUNT_IN, CHAIN_IN_ID, CHAIN_OUT_ID, OFFERER, TOKEN_IN, TOKEN_OUT } fr
 const MOCK_DL_CONFIG_JSON = {
   routingType: RoutingType.DUTCH_LIMIT,
   offerer: OFFERER,
-  exclusivePeriodSecs: 24,
+  exclusivityOverrideBps: 24,
   auctionPeriodSecs: 60,
 };
 

--- a/test/unit/lib/entities/quoteResponse.test.ts
+++ b/test/unit/lib/entities/quoteResponse.test.ts
@@ -72,10 +72,8 @@ describe('QuoteResponse', () => {
       ],
     });
     const order = DutchLimitOrder.fromJSON(quote.toOrder(), quote.chainId);
-    const parsedValidation = parseValidation(order.info);
-    expect(parsedValidation.type).toEqual(ValidationType.ExclusiveFiller);
-    expect(parsedValidation.data!.filler).toEqual(FILLER);
-    expect(parsedValidation.data!.lastExclusiveTimestamp).toBeGreaterThan(Date.now() / 1000);
+    expect(order.info.exclusiveFiller).toEqual(FILLER);
+    expect(order.info.exclusivityOverrideBps.toString()).toEqual('12');
 
     expect(BigNumber.from(quote.toOrder().nonce).gt(0)).toBeTruthy();
   });

--- a/test/unit/lib/handlers/quote/schema.test.ts
+++ b/test/unit/lib/handlers/quote/schema.test.ts
@@ -184,6 +184,20 @@ describe('Post quote request validation', () => {
     expect(error).toBeDefined();
   });
 
+  it('should reject invalid exclusivity', () => {
+    let { error } = PostQuoteRequestBodyJoi.validate({
+      ...BASE_REQUEST_BODY,
+      exclusivityOverrideBps: 10001,
+    });
+    expect(error).toBeDefined();
+
+    ({ error } = PostQuoteRequestBodyJoi.validate({
+      ...BASE_REQUEST_BODY,
+      exclusivityOverrideBps: -1,
+    }));
+    expect(error).toBeDefined();
+  });
+
   it('should reject invalid type', () => {
     const { error } = PostQuoteRequestBodyJoi.validate({
       ...BASE_REQUEST_BODY,

--- a/test/unit/providers/transformers/QuoteTransformers/SyntheticUniswapXTransformer.test.ts
+++ b/test/unit/providers/transformers/QuoteTransformers/SyntheticUniswapXTransformer.test.ts
@@ -68,12 +68,12 @@ describe('SyntheticUniswapXTransformer', () => {
       ]);
 
       expect(transformed.length).toEqual(3);
-      
+
       const quoteByRoutingType: QuoteByRoutingType = {};
       transformed.forEach((quote) => (quoteByRoutingType[quote.routingType] = quote));
 
       // No change to the RFQ quote
-      expect(transformed[0].amountOut).toEqual(DL_QUOTE_NATIVE_EXACT_IN_BETTER.amountOut)
+      expect(transformed[0].amountOut).toEqual(DL_QUOTE_NATIVE_EXACT_IN_BETTER.amountOut);
 
       const outStartAmount = applyWETHGasAdjustment(NATIVE_ADDRESS, CLASSIC_QUOTE_EXACT_IN_LARGE_GAS)
         .mul(DutchLimitQuote.improvementExactIn)
@@ -87,7 +87,7 @@ describe('SyntheticUniswapXTransformer', () => {
             endAmount: outEndAmount.toString(),
           },
         ],
-      })
+      });
     });
   });
 

--- a/test/utils/fixtures.ts
+++ b/test/utils/fixtures.ts
@@ -41,7 +41,7 @@ export const QUOTE_REQUEST_BODY_MULTI = {
     {
       routingType: RoutingType.DUTCH_LIMIT,
       offerer: OFFERER,
-      exclusivePeriodSecs: 12,
+      exclusivityOverrideBps: 12,
       auctionPeriodSecs: 60,
     },
     {
@@ -76,7 +76,7 @@ export function makeDutchLimitRequest(overrides: Partial<QuoteRequestBodyJSON>):
       {
         routingType: RoutingType.DUTCH_LIMIT,
         offerer: OFFERER,
-        exclusivePeriodSecs: 12,
+        exclusivityOverrideBps: 12,
         auctionPeriodSecs: 60,
       },
     ],
@@ -98,7 +98,7 @@ export const QUOTE_REQUEST_MULTI = parseQuoteRequests({
     {
       routingType: RoutingType.DUTCH_LIMIT,
       offerer: OFFERER,
-      exclusivePeriodSecs: 12,
+      exclusivityOverrideBps: 12,
       auctionPeriodSecs: 60,
     },
     {
@@ -115,7 +115,7 @@ export const QUOTE_REQUEST_ETH_IN_MULTI = parseQuoteRequests({
     {
       routingType: RoutingType.DUTCH_LIMIT,
       offerer: OFFERER,
-      exclusivePeriodSecs: 12,
+      exclusivityOverrideBps: 12,
       auctionPeriodSecs: 60,
     },
     {
@@ -132,7 +132,7 @@ export const QUOTE_REQUEST_MULTI_EXACT_OUT = parseQuoteRequests({
     {
       routingType: RoutingType.DUTCH_LIMIT,
       offerer: OFFERER,
-      exclusivePeriodSecs: 12,
+      exclusivityOverrideBps: 12,
       auctionPeriodSecs: 60,
     },
     {
@@ -231,7 +231,12 @@ export const CLASSIC_QUOTE_EXACT_IN_LARGE = createClassicQuote(
 );
 export const CLASSIC_QUOTE_EXACT_IN_LARGE_GAS = createClassicQuote(
   // quote: 1 ETH, quoteGasAdjusted: 0.9 ETH, gasUseEstimate: 100000, gasUseEstimateQuote: 0.1 ETH
-  { quote: '10000000000000000000000', quoteGasAdjusted: '9000000000000000000000', gasUseEstimate: '100000', gasUseEstimateQuote: '1000000000000000000000' },
+  {
+    quote: '10000000000000000000000',
+    quoteGasAdjusted: '9000000000000000000000',
+    gasUseEstimate: '100000',
+    gasUseEstimateQuote: '1000000000000000000000',
+  },
   'EXACT_INPUT'
 );
 


### PR DESCRIPTION
Exclusivity is now built into the order and has override as
a specifyable parameter. Exclusivity time is also now tied to startTime
so should not be a param. I checked and interface never uses that field
so its safe to remove
