### PR TITLE
fix-attempt: remove unnecessary echo

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -184,8 +184,6 @@ export class APIPipeline extends Stack {
         'git config --global url."https://${GH_TOKEN}@github.com/".insteadOf ssh://git@github.com/',
         'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc',
         'echo "UNISWAP_API=${UNISWAP_API}" > .env',
-        'echo "ARCHIVE_NODE_RPC=${ARCHIVE_NODE_RPC}" >> .env',
-        'echo "ROUTING_API=${ROUTING_API}" > .env',
         'yarn install --frozen-lockfile --network-concurrency 1',
         'yarn build',
         'yarn test:integ',


### PR DESCRIPTION
Still getting ` Phase context status code: Secrets Manager Error Message: AccessDeniedException: Access to KMS is not allowed` even though URA service accounts have access to the encryption key. I know the echos are unnecessary since they should already be injected into env by CDK