### PR TITLE
feat: prefer dutch orders

### DIFF
--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -19,6 +19,11 @@ import { APIHandleRequestParams, ApiRInj, ErrorResponse, Response } from '../bas
 import { ContainerInjected, QuoterByRoutingType } from './injector';
 import { PostQuoteRequestBodyJoi } from './schema';
 
+// number of bps per whole
+const BPS = 10000;
+// amount of price preference for dutch limit orders
+const DUTCH_LIMIT_PREFERENCE_BUFFER_BPS = 500;
+
 export interface QuoteResponseJSON {
   routing: string;
   quote: QuoteJSON;
@@ -143,11 +148,15 @@ const getQuotedAmount = (quote: Quote, tradeType: TradeType) => {
   if (tradeType === TradeType.EXACT_INPUT) {
     if (quote.routingType === RoutingType.CLASSIC) {
       return (quote as ClassicQuote).amountOutGasAdjusted;
+    } else if (quote.routingType === RoutingType.DUTCH_LIMIT) {
+      return (quote as Quote).amountOut.mul(BPS + DUTCH_LIMIT_PREFERENCE_BUFFER_BPS).div(BPS);
     }
     return (quote as Quote).amountOut;
   } else {
     if (quote.routingType === RoutingType.CLASSIC) {
       return (quote as ClassicQuote).amountInGasAdjusted;
+    } else if (quote.routingType === RoutingType.DUTCH_LIMIT) {
+      return (quote as Quote).amountIn.mul(BPS - DUTCH_LIMIT_PREFERENCE_BUFFER_BPS).div(BPS);
     }
     return (quote as Quote).amountIn;
   }

--- a/test/unit/lib/handlers/quote/handler.test.ts
+++ b/test/unit/lib/handlers/quote/handler.test.ts
@@ -12,11 +12,13 @@ import { Quoter } from '../../../../../lib/providers/quoters';
 import { CHECKSUM_OFFERER } from '../../../../constants';
 import {
   CLASSIC_QUOTE_EXACT_IN_BETTER,
+  CLASSIC_QUOTE_EXACT_IN_BETTER_PREFERENCE,
   CLASSIC_QUOTE_EXACT_IN_WORSE,
   CLASSIC_QUOTE_EXACT_OUT_BETTER,
   CLASSIC_QUOTE_EXACT_OUT_WORSE,
   DL_QUOTE_EXACT_IN_BETTER,
   DL_QUOTE_EXACT_IN_WORSE,
+  DL_QUOTE_EXACT_IN_WORSE_PREFERENCE,
   DL_QUOTE_EXACT_OUT_BETTER,
   DL_QUOTE_EXACT_OUT_WORSE,
   QUOTE_REQUEST_BODY_MULTI,
@@ -175,9 +177,34 @@ describe('QuoteHandler', () => {
       expect(compareQuotes(DL_QUOTE_EXACT_OUT_BETTER, CLASSIC_QUOTE_EXACT_OUT_WORSE, TradeType.EXACT_OUTPUT)).toBe(
         true
       );
+    });
+
+    it('returns false if lhs is better but rhs dutch limit preference overcomes', () => {
       expect(compareQuotes(CLASSIC_QUOTE_EXACT_OUT_BETTER, DL_QUOTE_EXACT_OUT_WORSE, TradeType.EXACT_OUTPUT)).toBe(
-        true
+        false
       );
+
+      expect(
+        compareQuotes(
+          CLASSIC_QUOTE_EXACT_IN_BETTER_PREFERENCE,
+          DL_QUOTE_EXACT_IN_WORSE_PREFERENCE,
+          TradeType.EXACT_INPUT
+        )
+      ).toBe(false);
+    });
+
+    it('returns true if rhs is better but lhs dutch limit preference overcomes', () => {
+      expect(compareQuotes(DL_QUOTE_EXACT_OUT_WORSE, CLASSIC_QUOTE_EXACT_OUT_BETTER, TradeType.EXACT_OUTPUT)).toBe(
+        false
+      );
+
+      expect(
+        compareQuotes(
+          CLASSIC_QUOTE_EXACT_IN_BETTER_PREFERENCE,
+          DL_QUOTE_EXACT_IN_WORSE_PREFERENCE,
+          TradeType.EXACT_INPUT
+        )
+      ).toBe(false);
     });
 
     it('returns false if lhs is a worse mixed type', () => {

--- a/test/utils/fixtures.ts
+++ b/test/utils/fixtures.ts
@@ -216,12 +216,17 @@ export const DL_QUOTE_NATIVE_EXACT_IN_BETTER = createDutchLimitQuote(
   { amountOut: '2', tokenIn: WRAPPED_NATIVE_CURRENCY[ID_TO_CHAIN_ID(CHAIN_OUT_ID)].address },
   'EXACT_INPUT'
 );
+export const DL_QUOTE_EXACT_IN_WORSE_PREFERENCE = createDutchLimitQuote({ amountOut: '100000' }, 'EXACT_INPUT');
 export const DL_QUOTE_EXACT_IN_WORSE = createDutchLimitQuote({ amountOut: '1' }, 'EXACT_INPUT');
 export const DL_QUOTE_EXACT_IN_LARGE = createDutchLimitQuote({ amountOut: '10000' }, 'EXACT_INPUT');
 export const DL_QUOTE_EXACT_OUT_BETTER = createDutchLimitQuote({ amountIn: '1' }, 'EXACT_OUTPUT');
 export const DL_QUOTE_EXACT_OUT_WORSE = createDutchLimitQuote({ amountIn: '2' }, 'EXACT_OUTPUT');
 export const DL_QUOTE_EXACT_OUT_LARGE = createDutchLimitQuote({ amountOut: '10000' }, 'EXACT_INPUT');
 
+export const CLASSIC_QUOTE_EXACT_IN_BETTER_PREFERENCE = createClassicQuote(
+  { quote: '100100', quoteGasAdjusted: '100100' },
+  'EXACT_INPUT'
+);
 export const CLASSIC_QUOTE_EXACT_IN_BETTER = createClassicQuote({ quote: '2', quoteGasAdjusted: '2' }, 'EXACT_INPUT');
 export const CLASSIC_QUOTE_EXACT_IN_WORSE = createClassicQuote({ quote: '1', quoteGasAdjusted: '1' }, 'EXACT_INPUT');
 export const CLASSIC_QUOTE_EXACT_IN_LARGE = createClassicQuote(


### PR DESCRIPTION
This commit updates the getBestQuote logic to prefer dutch orders by
a given proportion of the trade size. This helps compensate for the
extra gas overhead of dutch execution
