### PR TITLE
feat: dont filter rfq quotes by size

### DIFF
--- a/lib/providers/transformers/QuoteTransformers/UniswapXOrderSizeFilter.ts
+++ b/lib/providers/transformers/QuoteTransformers/UniswapXOrderSizeFilter.ts
@@ -1,6 +1,7 @@
+import { DutchLimitOrderInfoJSON } from '@uniswap/gouda-sdk';
 import { TradeType } from '@uniswap/sdk-core';
 import Logger from 'bunyan';
-import { BigNumber } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 
 import { QuoteTransformer } from '..';
 import { RoutingType } from '../../../constants';
@@ -49,6 +50,10 @@ export class UniswapXOrderSizeFilter implements QuoteTransformer {
     // filter any dutch quotes that are too small relative to gas
     return quotes.filter((quote) => {
       if (quote.routingType !== RoutingType.DUTCH_LIMIT) {
+        return true;
+      }
+
+      if ((quote.toJSON() as DutchLimitOrderInfoJSON).exclusiveFiller !== ethers.constants.AddressZero) {
         return true;
       }
 

--- a/test/unit/providers/transformers/QuoteTransformers/UniswapXOrderSizeFilter.test.ts
+++ b/test/unit/providers/transformers/QuoteTransformers/UniswapXOrderSizeFilter.test.ts
@@ -72,6 +72,23 @@ describe('UniswapXOrderSizeFilter', () => {
       expect(filtered.length).toEqual(1);
       expect(filtered[0]).toEqual(classicQuote);
     });
+
+    it('does not filter if exclusive filler is set', async () => {
+      const amountOut = ethers.utils.parseEther('1');
+      const twentyFivePercent = amountOut.mul(25).div(100);
+      const dutchQuote = createDutchLimitQuote(
+        { amountOut: amountOut.toString(), filler: '0x0000000000000000000000000000000000000001' },
+        'EXACT_INPUT'
+      );
+      const classicQuote = createClassicQuote(
+        { quote: amountOut.toString(), quoteGasAdjusted: amountOut.sub(twentyFivePercent).toString() },
+        'EXACT_INPUT'
+      );
+      const filtered = await filter.transform(QUOTE_REQUEST_MULTI, [classicQuote, dutchQuote]);
+      expect(filtered.length).toEqual(2);
+      expect(filtered[0]).toEqual(classicQuote);
+      expect(filtered[1]).toEqual(dutchQuote);
+    });
   });
 
   describe('ExactOut', () => {


### PR DESCRIPTION
They've already quoted it so clearly the size is fine for them
