### PR TITLE
fix: concat to .env instead of replacing

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -184,10 +184,9 @@ export class APIPipeline extends Stack {
       commands: [
         'git config --global url."https://${GH_TOKEN}@github.com/".insteadOf ssh://git@github.com/',
         'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc',
-        'echo "UNISWAP_API=${UNISWAP_API}" > .env',
-        'echo "ROUTING_API_URL=${ROUTING_API}" > .env',
-        'echo "ARCHIVE_NODE_RPC=${ARCHIVE_NODE_RPC}" > .env',
-        'cat .env',
+        'echo "UNISWAP_API=${UNISWAP_API}" >> .env',
+        'echo "ROUTING_API_URL=${ROUTING_API}" >> .env',
+        'echo "ARCHIVE_NODE_RPC=${ARCHIVE_NODE_RPC}" >> .env',
         'yarn install --frozen-lockfile --network-concurrency 1',
         'yarn build',
         'yarn test:integ',


### PR DESCRIPTION
we were replacing the .env file with every echo so it only contains ARCHIVE_NODE_RPC in the end