### PR TITLE
feat: filter rfq by tokenlist

### DIFF
--- a/lib/entities/context/ClassicQuoteContext.ts
+++ b/lib/entities/context/ClassicQuoteContext.ts
@@ -15,7 +15,7 @@ export class ClassicQuoteContext implements QuoteContext {
     return [this.request];
   }
 
-  resolve(dependencies: QuoteByKey): Quote | null {
+  async resolve(dependencies: QuoteByKey): Promise<Quote | null> {
     this.log.info({ dependencies }, 'Resolving classic quote');
     const quote = dependencies[this.request.key()];
 

--- a/lib/entities/context/index.ts
+++ b/lib/entities/context/index.ts
@@ -26,7 +26,7 @@ export interface QuoteContext {
   // params should be in the same order as dependencies response
   // but resolved with quotes
   // returns null if no usable quote is resolved
-  resolve(dependencies: QuoteByKey): Quote | null;
+  resolve(dependencies: QuoteByKey): Promise<Quote | null>;
 }
 
 // handler for quote contexts and their dependencies
@@ -60,18 +60,20 @@ export class QuoteContextManager {
   }
 
   // resolve quotes from quote contexts using quoted dependencies
-  resolveQuotes(quotes: Quote[]): Quote[] {
+  async resolveQuotes(quotes: Quote[]): Promise<Quote[]> {
     this.log.info({ quotes }, `Context quotes`);
     const allQuotes: QuoteByKey = {};
     for (const quote of quotes) {
       allQuotes[quote.request.key()] = quote;
     }
 
-    return this.contexts
-      .map((context) => {
+    const resolved = await Promise.all(
+      this.contexts.map((context) => {
         return context.resolve(allQuotes);
       })
-      .filter((quote) => quote !== null) as Quote[];
+    );
+
+    return resolved.filter((quote) => quote !== null) as Quote[];
   }
 }
 

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -57,7 +57,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     const quotes = await getQuotes(quoters, requests);
     log.info({ rawQuotes: quotes }, 'quotes');
 
-    const resolvedQuotes = contextHandler.resolveQuotes(quotes);
+    const resolvedQuotes = await contextHandler.resolveQuotes(quotes);
     log.info({ resolvedQuotes: quotes }, 'resolvedQuotes');
 
     const uniswapXRequested = requests.filter((request) => request.routingType === RoutingType.DUTCH_LIMIT).length > 0;

--- a/test/unit/lib/entities/context/ClassicQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/ClassicQuoteContext.test.ts
@@ -20,25 +20,25 @@ describe('ClassicQuoteContext', () => {
   });
 
   describe('resolve', () => {
-    it('returns null if no quotes given', () => {
+    it('returns null if no quotes given', async () => {
       const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC);
-      expect(context.resolve({})).toEqual(null);
+      expect(await context.resolve({})).toEqual(null);
     });
 
-    it('still returns quote if too many dependencies given', () => {
+    it('still returns quote if too many dependencies given', async () => {
       const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC);
       expect(
-        context.resolve({
+        await context.resolve({
           [QUOTE_REQUEST_CLASSIC.key()]: CLASSIC_QUOTE_EXACT_IN_BETTER,
           [CLASSIC_QUOTE_EXACT_OUT_WORSE.request.key()]: CLASSIC_QUOTE_EXACT_IN_WORSE,
         })
       ).toEqual(CLASSIC_QUOTE_EXACT_IN_BETTER);
     });
 
-    it('returns quote', () => {
+    it('returns quote', async () => {
       const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC);
       expect(
-        context.resolve({
+        await context.resolve({
           [QUOTE_REQUEST_CLASSIC.key()]: CLASSIC_QUOTE_EXACT_IN_BETTER,
         })
       ).toEqual(CLASSIC_QUOTE_EXACT_IN_BETTER);

--- a/test/unit/lib/entities/context/QuoteContextHandler.test.ts
+++ b/test/unit/lib/entities/context/QuoteContextHandler.test.ts
@@ -25,7 +25,7 @@ class MockQuoteContext implements QuoteContext {
     return this._dependencies;
   }
 
-  resolve(dependencies: QuoteByKey): Quote | null {
+  async resolve(dependencies: QuoteByKey): Promise<Quote | null> {
     this._quoteDependencies = dependencies;
     return this._quote;
   }
@@ -189,30 +189,30 @@ describe('QuoteContextManager', () => {
   });
 
   describe('resolveQuotes', () => {
-    it('passes null if no matching quote', () => {
+    it('passes null if no matching quote', async () => {
       const context = new MockQuoteContext(QUOTE_REQUEST_DL);
       context.setDependencies([QUOTE_REQUEST_CLASSIC]);
       const handler = new QuoteContextManager(logger, [context]);
-      expect(handler.resolveQuotes([])).toEqual([]);
+      expect(await handler.resolveQuotes([])).toEqual([]);
       expect(context._quoteDependencies).toEqual({});
     });
 
-    it('passes matching dependencies', () => {
+    it('passes matching dependencies', async () => {
       const context = new MockQuoteContext(QUOTE_REQUEST_DL);
       context.setDependencies([CLASSIC_QUOTE_EXACT_IN_BETTER.request]);
       const handler = new QuoteContextManager(logger, [context]);
-      handler.resolveQuotes([DL_QUOTE_EXACT_IN_BETTER, CLASSIC_QUOTE_EXACT_IN_BETTER]);
+      await handler.resolveQuotes([DL_QUOTE_EXACT_IN_BETTER, CLASSIC_QUOTE_EXACT_IN_BETTER]);
       expect(context._quoteDependencies).toEqual({
         [DL_QUOTE_EXACT_IN_BETTER.request.key()]: DL_QUOTE_EXACT_IN_BETTER,
         [CLASSIC_QUOTE_EXACT_IN_BETTER.request.key()]: CLASSIC_QUOTE_EXACT_IN_BETTER,
       });
     });
 
-    it('passes matching dependencies in the proper order', () => {
+    it('passes matching dependencies in the proper order', async () => {
       const context = new MockQuoteContext(QUOTE_REQUEST_DL);
       context.setDependencies([DL_QUOTE_EXACT_IN_BETTER.request, CLASSIC_QUOTE_EXACT_IN_BETTER.request]);
       const handler = new QuoteContextManager(logger, [context]);
-      handler.resolveQuotes([CLASSIC_QUOTE_EXACT_IN_BETTER, DL_QUOTE_EXACT_IN_BETTER]);
+      await handler.resolveQuotes([CLASSIC_QUOTE_EXACT_IN_BETTER, DL_QUOTE_EXACT_IN_BETTER]);
       expect(context._quoteDependencies).toEqual({
         [DL_QUOTE_EXACT_IN_BETTER.request.key()]: DL_QUOTE_EXACT_IN_BETTER,
         [DL_QUOTE_EXACT_IN_BETTER.request.key()]: DL_QUOTE_EXACT_IN_BETTER,
@@ -220,11 +220,11 @@ describe('QuoteContextManager', () => {
       });
     });
 
-    it('passes one matching and one not matching', () => {
+    it('passes one matching and one not matching', async () => {
       const context = new MockQuoteContext(QUOTE_REQUEST_DL);
       context.setDependencies([DL_QUOTE_EXACT_IN_BETTER.request, CLASSIC_QUOTE_EXACT_IN_BETTER.request]);
       const handler = new QuoteContextManager(logger, [context]);
-      handler.resolveQuotes([CLASSIC_QUOTE_EXACT_OUT_WORSE, DL_QUOTE_EXACT_IN_BETTER]);
+      await handler.resolveQuotes([CLASSIC_QUOTE_EXACT_OUT_WORSE, DL_QUOTE_EXACT_IN_BETTER]);
       expect(context._quoteDependencies).toEqual({
         [DL_QUOTE_EXACT_IN_BETTER.request.key()]: DL_QUOTE_EXACT_IN_BETTER,
         [CLASSIC_QUOTE_EXACT_OUT_WORSE.request.key()]: CLASSIC_QUOTE_EXACT_OUT_WORSE,


### PR DESCRIPTION
Use a tokenlist as a filter stage for rfq quotes to determine if gouda
is sensible. Currently using default tokenlist but we should craft our
custom gouda-specific tokenlist
