### PR TITLE
fix: remove `checkDefined` for local

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -14,7 +14,6 @@ import { APIStack } from './stacks/api-stack';
 import { SUPPORTED_CHAINS } from '../lib/config/chains';
 import { RoutingType } from '../lib/constants';
 import { ChainId } from '@uniswap/smart-order-router';
-import { checkDefined } from '../lib/util/preconditions';
 
 dotenv.config();
 
@@ -235,7 +234,7 @@ envVars['RESPONSE_DESTINATION_ARN'] = process.env['RESPONSE_DESTINATION_ARN'] ||
 const jsonRpcProviders = {} as { [chainKey: string]: string }
     SUPPORTED_CHAINS[RoutingType.CLASSIC].forEach((chainId: ChainId) => {
       const mapKey = `RPC_${chainId}`
-      jsonRpcProviders[mapKey] = checkDefined(process.env[mapKey], mapKey)
+      jsonRpcProviders[mapKey] = process.env[mapKey] || '';
 })
 
 new APIStack(app, `${SERVICE_NAME}Stack`, {


### PR DESCRIPTION
# Description
The use of `checkDefined` when deploying from local [breaks](https://us-east-2.console.aws.amazon.com/codesuite/codebuild/644039819003/projects/UnifiedRoutingPipelineBuild-InEaxh12tkCq/build/UnifiedRoutingPipelineBuild-InEaxh12tkCq%3A042615a5-5ef7-4aa0-a8af-e4511b95408d/?region=us-east-2) the Codepipeline Codebuild phase.
This PR removes the check.