### PR TITLE
Revert "bump beta rate limit for load test"

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -105,9 +105,7 @@ export class APIStack extends cdk.Stack {
           statement: {
             rateBasedStatement: {
               // Limit is per 5 mins, i.e. 120 requests every 5 mins
-              limit: stage == STAGE.BETA
-              ? 5000 // temporarily increase limit for load testing against beta
-              : props.throttlingOverride ? parseInt(props.throttlingOverride) : 120,
+              limit: props.throttlingOverride ? parseInt(props.throttlingOverride) : 120,
               // API is of type EDGE so is fronted by Cloudfront as a proxy.
               // Use the ip set in X-Forwarded-For by Cloudfront, not the regular IP
               // which would just resolve to Cloudfronts IP.


### PR DESCRIPTION
Reverts Uniswap/unified-routing-api#111