### PR TITLE
feat: cleanup slippage tolerance

### DIFF
--- a/lib/entities/quote/DutchLimitQuote.ts
+++ b/lib/entities/quote/DutchLimitQuote.ts
@@ -167,7 +167,7 @@ export class DutchLimitQuote implements Quote {
       quoteId: this.quoteId,
       requestId: this.requestId,
       auctionPeriodSecs: this.request.config.auctionPeriodSecs,
-      slippageTolerance: this.request.slippageTolerance,
+      slippageTolerance: this.request.info.slippageTolerance,
     };
   }
 
@@ -219,7 +219,7 @@ export class DutchLimitQuote implements Quote {
       offerer: this.offerer,
       filler: this.filler,
       routing: RoutingType[this.routingType],
-      slippage: parseFloat(this.request.slippageTolerance),
+      slippage: parseFloat(this.request.info.slippageTolerance),
       createdAt: this.createdAt,
     };
   }
@@ -252,13 +252,13 @@ export class DutchLimitQuote implements Quote {
       return {
         amountIn: amountInStart,
         amountOut: amountOutStart
-          .mul(HUNDRED_PERCENT.sub(BigNumber.from(request.slippageTolerance)))
+          .mul(HUNDRED_PERCENT.sub(BigNumber.from(request.info.slippageTolerance)))
           .div(HUNDRED_PERCENT),
       };
     } else {
       return {
         amountIn: amountInStart
-          .mul(HUNDRED_PERCENT.add(BigNumber.from(request.slippageTolerance)))
+          .mul(HUNDRED_PERCENT.add(BigNumber.from(request.info.slippageTolerance)))
           .div(HUNDRED_PERCENT),
         amountOut: amountOutStart,
       };

--- a/test/unit/lib/fetchers/Permit2Fetcher.test.ts
+++ b/test/unit/lib/fetchers/Permit2Fetcher.test.ts
@@ -1,6 +1,5 @@
 import { PERMIT2_ADDRESS } from '@uniswap/permit2-sdk';
 import { ChainId } from '@uniswap/smart-order-router';
-import * as _ from 'lodash';
 import PERMIT2_CONTRACT from '../../../../lib/abis/Permit2.json';
 import { Permit2Fetcher } from '../../../../lib/fetchers/Permit2Fetcher';
 


### PR DESCRIPTION
for Dutch it is always defined because we override it with default, this
commit types it this way so we dont have to do null checks in other
places
