### PR TITLE
feat: use error enums and NoQuotesAvailable error

### DIFF
--- a/lib/handlers/base/api-handler.ts
+++ b/lib/handlers/base/api-handler.ts
@@ -8,14 +8,14 @@ import {
 import { default as bunyan, default as Logger } from 'bunyan';
 import Joi from 'joi';
 
-import { ValidationError } from '../../util/errors';
+import { CustomError, ErrorCode } from '../../util/errors';
 import { BaseHandleRequestParams, BaseInjector, BaseLambdaHandler, BaseRInj } from './base';
 
 const INTERNAL_ERROR = (id?: string) => {
   return {
     statusCode: 500,
     body: JSON.stringify({
-      errorCode: 'INTERNAL_ERROR',
+      errorCode: ErrorCode.InternalError,
       detail: 'Unexpected error',
       id,
     }),
@@ -46,7 +46,7 @@ export type Response<Res> = {
 
 export type ErrorResponse = {
   statusCode: 400 | 403 | 404 | 408 | 409 | 500;
-  errorCode?: string;
+  errorCode?: ErrorCode;
   detail?: string;
 };
 
@@ -184,7 +184,7 @@ export abstract class APIGLambdaHandler<
           }
         } catch (err) {
           log.error({ err }, 'Unexpected error in handler');
-          if (err instanceof ValidationError) {
+          if (err instanceof CustomError) {
             return err.toJSON(id);
           }
 
@@ -268,7 +268,7 @@ export abstract class APIGLambdaHandler<
             statusCode: 422,
             body: JSON.stringify({
               detail: 'Invalid JSON body',
-              errorCode: 'VALIDATION_ERROR',
+              errorCode: ErrorCode.ValidationError,
             }),
           },
         };
@@ -293,7 +293,7 @@ export abstract class APIGLambdaHandler<
             statusCode: 400,
             body: JSON.stringify({
               detail: queryParamsValidation.error.message,
-              errorCode: 'VALIDATION_ERROR',
+              errorCode: ErrorCode.ValidationError,
             }),
           },
         };
@@ -319,7 +319,7 @@ export abstract class APIGLambdaHandler<
             statusCode: 400,
             body: JSON.stringify({
               detail: bodyValidation.error.message,
-              errorCode: 'VALIDATION_ERROR',
+              errorCode: ErrorCode.ValidationError,
             }),
           },
         };

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -19,7 +19,7 @@ import {
   QuoteRequestBodyJSON,
   QuoteRequestInfo,
 } from '../../entities';
-import { ValidationError } from '../../util/errors';
+import { NoQuotesAvailable, ValidationError } from '../../util/errors';
 import { log } from '../../util/log';
 import { metrics } from '../../util/metrics';
 import { currentTimestampInSeconds } from '../../util/time';
@@ -90,11 +90,7 @@ export class QuoteHandler extends APIGLambdaHandler<
     const uniswapXRequested = requests.filter((request) => request.routingType === RoutingType.DUTCH_LIMIT).length > 0;
     const bestQuote = await getBestQuote(resolvedQuotes.filter((q) => q !== null) as Quote[], uniswapXRequested);
     if (!bestQuote) {
-      return {
-        statusCode: 404,
-        detail: 'No quotes available',
-        errorCode: 'QUOTE_ERROR',
-      };
+      throw new NoQuotesAvailable();
     }
 
     // TODO: generate and put at quote-level

--- a/lib/util/errors.ts
+++ b/lib/util/errors.ts
@@ -1,6 +1,16 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
 
-export class ValidationError extends Error {
+export enum ErrorCode {
+  ValidationError = 'VALIDATION_ERROR',
+  InternalError = 'INTERNAL_ERROR',
+  QuoteError = 'QUOTE_ERROR',
+}
+
+export abstract class CustomError extends Error {
+  abstract toJSON(id?: string): APIGatewayProxyResult;
+}
+
+export class ValidationError extends CustomError {
   constructor(message: string) {
     super(message);
     // Set the prototype explicitly.
@@ -11,7 +21,28 @@ export class ValidationError extends Error {
     return {
       statusCode: 400,
       body: JSON.stringify({
-        errorCode: 'VALIDATION_ERROR',
+        errorCode: ErrorCode.ValidationError,
+        detail: this.message,
+        id,
+      }),
+    };
+  }
+}
+
+export class NoQuotesAvailable extends CustomError {
+  private static MESSAGE = 'No quotes available';
+
+  constructor() {
+    super(NoQuotesAvailable.MESSAGE);
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, NoQuotesAvailable.prototype);
+  }
+
+  toJSON(id?: string): APIGatewayProxyResult {
+    return {
+      statusCode: 404,
+      body: JSON.stringify({
+        errorCode: ErrorCode.QuoteError,
         detail: this.message,
         id,
       }),


### PR DESCRIPTION
This commit uses an enum for error codes. It also adds
a NoQuotesAvailable custom error
