### PR TITLE
fix: afterResponseHook returning 502 when request validation fails

### DIFF
--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -19,7 +19,7 @@ import {
   QuoteRequestBodyJSON,
   QuoteRequestInfo,
 } from '../../entities';
-import { NoQuotesAvailable, ValidationError } from '../../util/errors';
+import { ErrorCode, NoQuotesAvailable, ValidationError } from '../../util/errors';
 import { log } from '../../util/log';
 import { metrics } from '../../util/metrics';
 import { currentTimestampInSeconds } from '../../util/time';
@@ -152,11 +152,18 @@ export class QuoteHandler extends APIGLambdaHandler<
 
   protected afterResponseHook(event: APIGatewayProxyEvent, _context: Context, response: APIGatewayProxyResult): void {
     const { statusCode } = response;
+    const responseBody = JSON.parse(response.body!);
+    const rawBody = JSON.parse(event.body!);
+
+    log.info({ rawBody }, 'rawBody');
+    if (statusCode != 200 && responseBody.errorCode == ErrorCode.ValidationError) {
+      metrics.putMetric(`QuoteRequestValidationError`, 1);
+      return;
+    }
 
     // Try and extract the chain id from the raw json.
     let chainId = '0';
     try {
-      const rawBody = JSON.parse(event.body!);
       chainId = rawBody.tokenInChainId ?? rawBody.chainId;
     } catch (err) {
       // no-op. If we can't get chainId still log the metric as chain 0


### PR DESCRIPTION
issue is that we are assuming request is valid in afterResponseHook