### PR TITLE
fix: skip invalid orders

### DIFF
--- a/lib/entities/context/DutchQuoteContext.ts
+++ b/lib/entities/context/DutchQuoteContext.ts
@@ -127,7 +127,10 @@ export class DutchQuoteContext implements QuoteContext {
       return null;
     }
 
-    return DutchQuote.reparameterize(quote, classicQuote as ClassicQuote);
+    const reparameterized = DutchQuote.reparameterize(quote, classicQuote as ClassicQuote);
+    // if its invalid for some reason, i.e. too much decay then return null
+    if (!reparameterized.validate()) return null;
+    return reparameterized;
   }
 
   // transform a classic quote into a synthetic dutch quote

--- a/lib/entities/quote/DutchQuote.ts
+++ b/lib/entities/quote/DutchQuote.ts
@@ -6,7 +6,7 @@ import { PermitTransferFromData } from '@uniswap/permit2-sdk';
 import { v4 as uuidv4 } from 'uuid';
 import { Quote, QuoteJSON } from '.';
 import { DutchRequest } from '..';
-import { BPS, UNISWAPX_BASE_GAS, NATIVE_ADDRESS, RoutingType, WETH_UNWRAP_GAS, WETH_WRAP_GAS } from '../../constants';
+import { BPS, NATIVE_ADDRESS, RoutingType, UNISWAPX_BASE_GAS, WETH_UNWRAP_GAS, WETH_WRAP_GAS } from '../../constants';
 import { log } from '../../util/log';
 import { generateRandomNonce } from '../../util/nonce';
 import { currentTimestampInSeconds } from '../../util/time';
@@ -247,6 +247,12 @@ export class DutchQuote implements Quote {
 
   public get amountIn(): BigNumber {
     return this.amountInStart;
+  }
+
+  validate(): boolean {
+    if (this.amountOutStart.lt(this.amountOutEnd)) return false;
+    if (this.amountInStart.gt(this.amountInEnd)) return false;
+    return true;
   }
 
   // static helpers

--- a/test/unit/lib/entities/context/DutchQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/DutchQuoteContext.test.ts
@@ -151,7 +151,7 @@ describe('DutchQuoteContext', () => {
       });
       const context = new DutchQuoteContext(logger, request);
       const filler = '0x1111111111111111111111111111111111111111';
-      const rfqQuote = createDutchQuote({ amountOut: '1', filler }, 'EXACT_INPUT');
+      const rfqQuote = createDutchQuote({ amountOut: '1000000000000000000', filler }, 'EXACT_INPUT');
       expect(rfqQuote.filler).toEqual(filler);
       const classicQuote = createClassicQuote(
         { quote: '10000000000', quoteGasAdjusted: '9999000000' },
@@ -166,6 +166,27 @@ describe('DutchQuoteContext', () => {
       expect(quote?.request).toMatchObject(rfqQuote.request);
       expect(quote?.amountIn).toEqual(rfqQuote?.amountIn);
       expect(quote?.amountOut).toEqual(rfqQuote?.amountOut);
+    });
+
+    it('skips rfq if reparameterization makes the decay inverted', async () => {
+      const request = makeDutchRequest({
+        tokenOut: '0x1111111111111111111111111111111111111111',
+      });
+      const context = new DutchQuoteContext(logger, request);
+      const filler = '0x1111111111111111111111111111111111111111';
+      const rfqQuote = createDutchQuote({ amountOut: '1', filler }, 'EXACT_INPUT');
+      expect(rfqQuote.filler).toEqual(filler);
+      const classicQuote = createClassicQuote(
+        { quote: '10000000000', quoteGasAdjusted: '9999000000' },
+        { type: 'EXACT_INPUT' }
+      );
+      context.dependencies();
+
+      const quote = await context.resolve({
+        [context.requestKey]: rfqQuote,
+        [context.classicKey]: classicQuote,
+      });
+      expect(quote).toBeNull();
     });
 
     it('keeps synthetic if output is weth', async () => {


### PR DESCRIPTION
if the rfq quote is way worse than classic quote then sometimes we may
    parameterize the decay to be negative. This commit just skips those
    cases before we hit an internal error
