### PR TITLE
Feat: pass debug query string param to routing-api

### DIFF
--- a/lib/entities/request/ClassicRequest.ts
+++ b/lib/entities/request/ClassicRequest.ts
@@ -21,6 +21,8 @@ export interface ClassicConfig {
   minSplits?: number;
   forceCrossProtocol?: boolean;
   forceMixedRoutes?: boolean;
+  debugRoutingConfig?: string;
+  unicornSecret?: string;
 }
 
 export interface ClassicConfigJSON extends Omit<ClassicConfig, 'protocols' | 'permitAmount'> {

--- a/lib/providers/quoters/RoutingApiQuoter.ts
+++ b/lib/providers/quoters/RoutingApiQuoter.ts
@@ -96,6 +96,12 @@ export class RoutingApiQuoter implements Quoter {
         ...(config.permitSigDeadline !== undefined && { permitSigDeadline: config.permitSigDeadline }),
         ...(config.enableUniversalRouter !== undefined && { enableUniversalRouter: config.enableUniversalRouter }),
         ...(config.recipient !== undefined && { recipient: config.recipient }),
+        // unicorn secret is only used for debug routing config
+        // routing-api will only send the debug routing config that overrides the default routing config
+        // (a.k.a. alpha router config within smart-order-router) if unified-routing-api
+        // sends the correct unicorn secret
+        ...(config.debugRoutingConfig !== undefined && { debugRoutingConfig: config.debugRoutingConfig }),
+        ...(config.unicornSecret !== undefined && { unicornSecret: config.unicornSecret }),
       })
     );
   }


### PR DESCRIPTION
## What?
Quote Latencies have been high. We are exercising multiple paths to speed up the 1st quote. Ideas include:

1. Allow interface/mobile pass down the `debugRoutingConfig`, so that they can start experimenting/tuning with quote latencies without impacting prod traffics.
2. Routing backend keeps tuning and fixing the latencies bottlenecks in smart-order-router, and also leverage the `debugRoutingConfig` query string param without impacting prod traffics.

## Why?
quote latencies are a factor of many dynamic things, and we want to live perf test in prod to have the most accurate perf datapoints.

## How?
We are passing down this `debugRoutingConfig`, a JSON-stringified alpha-router [configs](https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/alpha-router.ts#L264).

## Testing?
Tested in my local unified-routing-api, against my routing-api, with the correct `unicornSecrets` on my local. I can see `debugRoutingConfig` gets passed onto the routing-api alpha-router configs. Checked the [log insights](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-3600~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*271-64e3e884-47faaed50fde2bb20c78aa1f*27*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2020~queryId~'ba6aa73b393a88f0-c61cb3a9-4902860-8c7550cf-54975fc53b648c7827a2c3~source~(~'*2faws*2flambda*2fUnifiedRoutingStack-QuoteE2906A56-0Vh6vBUeL8BF~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-jS6GXdZ1EYtE~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-pOSkckAzB5N6~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-xxMl8mSwRJxq~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-YwgyYPOqKbbD))) on my personal AWS account.

## Screenshots (optional)
<img width="1102" alt="Screenshot 2023-08-21 at 3 57 33 PM" src="https://github.com/Uniswap/unified-routing-api/assets/91580504/30f36bf8-9af1-4143-8c1a-e7b5f9939721">


## Anything Else?
Supposedly this should be the last step to support `debugRoutingConfig`. API (reverse proxy) should need no code changes.