### PR TITLE
Feat: Support fast 1st quote at the unified-routing-api level

### DIFF
--- a/lib/entities/request/ClassicRequest.ts
+++ b/lib/entities/request/ClassicRequest.ts
@@ -23,6 +23,7 @@ export interface ClassicConfig {
   forceMixedRoutes?: boolean;
   debugRoutingConfig?: string;
   unicornSecret?: string;
+  quoteSpeed?: string;
 }
 
 export interface ClassicConfigJSON extends Omit<ClassicConfig, 'protocols' | 'permitAmount'> {

--- a/lib/providers/quoters/RoutingApiQuoter.ts
+++ b/lib/providers/quoters/RoutingApiQuoter.ts
@@ -102,6 +102,10 @@ export class RoutingApiQuoter implements Quoter {
         // sends the correct unicorn secret
         ...(config.debugRoutingConfig !== undefined && { debugRoutingConfig: config.debugRoutingConfig }),
         ...(config.unicornSecret !== undefined && { unicornSecret: config.unicornSecret }),
+        // quote speed can be sent in standalone query string param
+        // expect web/mobile to send it for the 1st fast quote,
+        // otherwise default not to send it
+        ...(config.quoteSpeed !== undefined && { quoteSpeed: config.quoteSpeed }),
       })
     );
   }

--- a/lib/util/validator.ts
+++ b/lib/util/validator.ts
@@ -72,6 +72,8 @@ export class FieldValidator {
 
   public static readonly positiveNumber = Joi.number().greater(0);
 
+  public static readonly quoteSpeed = Joi.string().valid('fast', 'standard');
+
   public static readonly classicConfig = Joi.object({
     routingType: FieldValidator.routingType.required(),
     protocols: FieldValidator.protocols.required(),
@@ -90,6 +92,7 @@ export class FieldValidator {
     forceMixedRoutes: FieldValidator.forceMixedRoutes.optional(),
     slippageTolerance: FieldValidator.slippageTolerance.optional(),
     algorithm: FieldValidator.algorithm.optional(),
+    quoteSpeed: FieldValidator.quoteSpeed.optional(),
   });
 
   public static readonly dutchLimitConfig = Joi.object({


### PR DESCRIPTION
quoteSpeed = fast sent to local unified-routing-api, and correctly forwarded to the local routing-api:

```
{
   "amount":"1000000000000000000",
   "protocols":"v2,v3,mixed",
   "quoteSpeed":"fast",
   "tokenInAddress":"ETH",
   "tokenInChainId":"1",
   "tokenOutAddress":"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
   "tokenOutChainId":"1",
   "type":"exactIn"
},
"multiValueQueryStringParameters":{
   "amount":[
      "1000000000000000000"
   ],
   "protocols":[
      "v2,v3,mixed"
   ],
   "quoteSpeed":[
      "fast"
   ],
   "tokenInAddress":[
      "ETH"
   ],
   "tokenInChainId":[
      "1"
   ],
   "tokenOutAddress":[
      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
   ],
   "tokenOutChainId":[
      "1"
   ],
   "type":[
      "exactIn"
   ]
}
```

<img width="1153" alt="Screenshot 2023-08-24 at 10 29 13 AM" src="https://github.com/Uniswap/unified-routing-api/assets/91580504/d0a650b1-2a6d-430e-bea6-403c989147dc">
