### PR TITLE
feat: fetch synthetic status from UPA

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -129,6 +129,11 @@ export class APIPipeline extends Stack {
         'arn:aws:secretsmanager:us-east-2:644039819003:secret:gouda-parameterization-api-internal-api-key-uw4sIa',
     });
 
+    const syntheticSwitchApiKeySecret = sm.Secret.fromSecretAttributes(this, 'synthetic-switch-api-key', {
+      secretCompleteArn:
+        'arn:aws:secretsmanager:us-east-2:644039819003:secret:gouda-parameterization-api-internal-api-key-uw4sIa',
+    });
+
     const syntheticEligibleTokens = sm.Secret.fromSecretAttributes(
       this,
       'all/unified-routing-api/synthetic-eligible-tokens-2',

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -131,7 +131,7 @@ export class APIPipeline extends Stack {
 
     const syntheticSwitchApiKeySecret = sm.Secret.fromSecretAttributes(this, 'synthetic-switch-api-key', {
       secretCompleteArn:
-        'arn:aws:secretsmanager:us-east-2:644039819003:secret:gouda-parameterization-api-internal-api-key-uw4sIa',
+        'arn:aws:secretsmanager:us-east-2:644039819003:secret:UniswapX/ParamApi/ApiKeys-hYyUt1',
     });
 
     const syntheticEligibleTokens = sm.Secret.fromSecretAttributes(
@@ -156,6 +156,7 @@ export class APIPipeline extends Stack {
         ROUTING_API_KEY: routingApiKeySecret.secretValue.toString(),
         PARAMETERIZATION_API_KEY: parameterizationApiKeySecret.secretValue.toString(),
         PARAMETERIZATION_API_URL: urlSecrets.secretValueFromJson('PARAMETERIZATION_API_BETA').toString(),
+        SYNTH_SWITCH_API_KEY: syntheticSwitchApiKeySecret.secretValue.toString(),
         ROUTING_API_URL: urlSecrets.secretValueFromJson('ROUTING_API_BETA').toString(),
         SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_BETA').toString(),
         REQUEST_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_REQUEST_DESTINATION_BETA').toString(),
@@ -181,6 +182,7 @@ export class APIPipeline extends Stack {
         ROUTING_API_KEY: routingApiKeySecret.secretValue.toString(),
         PARAMETERIZATION_API_KEY: parameterizationApiKeySecret.secretValue.toString(),
         PARAMETERIZATION_API_URL: urlSecrets.secretValueFromJson('PARAMETERIZATION_API_PROD').toString(),
+        SYNTH_SWITCH_API_KEY: syntheticSwitchApiKeySecret.secretValue.toString(),
         ROUTING_API_URL: urlSecrets.secretValueFromJson('ROUTING_API_PROD').toString(),
         SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_PROD').toString(),
         REQUEST_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_REQUEST_DESTINATION_PROD').toString(),
@@ -269,6 +271,7 @@ const app = new cdk.App();
 const envVars: { [key: string]: string } = {};
 envVars['PARAMETERIZATION_API_URL'] = process.env['PARAMETERIZATION_API_URL'] || '';
 envVars['PARAMETERIZATION_API_KEY'] = process.env['PARAMETERIZATION_API_KEY'] || ''
+envVars['SYNTH_SWITCH_API_KEY'] = process.env['SYNTH_SWITCH_API_KEY'] || ''
 envVars['ROUTING_API_URL'] = process.env['ROUTING_API_URL'] || '';
 envVars['SERVICE_URL'] = process.env['SERVICE_URL'] || '';
 envVars['REQUEST_DESTINATION_ARN'] = process.env['REQUEST_DESTINATION_ARN'] || '';

--- a/lib/entities/context/ClassicQuoteContext.ts
+++ b/lib/entities/context/ClassicQuoteContext.ts
@@ -1,9 +1,13 @@
 import { UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk';
 import Logger from 'bunyan';
-import { QuoteByKey, QuoteContext, QuoteContextProviders } from '.';
+import { QuoteByKey, QuoteContext } from '.';
 import { RoutingType } from '../../constants';
 import { ClassicQuote, ClassicRequest, Quote, QuoteRequest } from '../../entities';
 import { Permit2Fetcher } from '../../fetchers/Permit2Fetcher';
+
+export type ClassicQuoteContextProviders = {
+  permit2Fetcher: Permit2Fetcher;
+};
 
 // manages context around a single top level classic quote request
 export class ClassicQuoteContext implements QuoteContext {
@@ -11,7 +15,7 @@ export class ClassicQuoteContext implements QuoteContext {
   private log: Logger;
   private permit2Fetcher: Permit2Fetcher;
 
-  constructor(_log: Logger, public request: ClassicRequest, providers: QuoteContextProviders) {
+  constructor(_log: Logger, public request: ClassicRequest, providers: ClassicQuoteContextProviders) {
     this.log = _log.child({ context: 'ClassicQuoteContext' });
     this.permit2Fetcher = providers.permit2Fetcher;
   }

--- a/lib/entities/context/ClassicQuoteContext.ts
+++ b/lib/entities/context/ClassicQuoteContext.ts
@@ -1,6 +1,6 @@
 import { UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk';
 import Logger from 'bunyan';
-import { QuoteByKey, QuoteContext } from '.';
+import { QuoteByKey, QuoteContext, QuoteContextProviders } from '.';
 import { RoutingType } from '../../constants';
 import { ClassicQuote, ClassicRequest, Quote, QuoteRequest } from '../../entities';
 import { Permit2Fetcher } from '../../fetchers/Permit2Fetcher';
@@ -9,9 +9,11 @@ import { Permit2Fetcher } from '../../fetchers/Permit2Fetcher';
 export class ClassicQuoteContext implements QuoteContext {
   routingType: RoutingType.CLASSIC;
   private log: Logger;
+  private permit2Fetcher: Permit2Fetcher;
 
-  constructor(_log: Logger, public request: ClassicRequest, private permit2Fetcher: Permit2Fetcher) {
+  constructor(_log: Logger, public request: ClassicRequest, providers: QuoteContextProviders) {
     this.log = _log.child({ context: 'ClassicQuoteContext' });
+    this.permit2Fetcher = providers.permit2Fetcher;
   }
 
   // classic quotes have no explicit dependencies and can be resolved by themselves

--- a/lib/entities/context/index.ts
+++ b/lib/entities/context/index.ts
@@ -4,6 +4,7 @@ import { RoutingType } from '../../constants';
 import { ClassicRequest, DutchRequest, Quote, QuoteRequest } from '../../entities';
 
 import { Permit2Fetcher } from '../../fetchers/Permit2Fetcher';
+import { SyntheticStatusProvider } from '../../providers';
 import { log } from '../../util/log';
 import { ClassicQuoteContext } from './ClassicQuoteContext';
 import { DutchQuoteContext } from './DutchQuoteContext';
@@ -80,17 +81,19 @@ export class QuoteContextManager {
   }
 }
 
-export function parseQuoteContexts(
-  requests: QuoteRequest[],
-  permit2Fetcher: Permit2Fetcher,
-  provider: ethers.providers.JsonRpcProvider
-): QuoteContext[] {
+export type QuoteContextProviders = {
+  permit2Fetcher: Permit2Fetcher;
+  rpcProvider: ethers.providers.JsonRpcProvider;
+  syntheticStatusProvider: SyntheticStatusProvider;
+};
+
+export function parseQuoteContexts(requests: QuoteRequest[], providers: QuoteContextProviders): QuoteContext[] {
   return requests.map((request) => {
     switch (request.routingType) {
       case RoutingType.DUTCH_LIMIT:
-        return new DutchQuoteContext(log, request as DutchRequest, provider);
+        return new DutchQuoteContext(log, request as DutchRequest, providers);
       case RoutingType.CLASSIC:
-        return new ClassicQuoteContext(log, request as ClassicRequest, permit2Fetcher);
+        return new ClassicQuoteContext(log, request as ClassicRequest, providers);
       default:
         throw new Error(`Unsupported routing type: ${request.routingType}`);
     }

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -55,7 +55,7 @@ export class QuoteHandler extends APIGLambdaHandler<
   ): Promise<ErrorResponse | Response<QuoteResponseJSON>> {
     const {
       requestBody,
-      containerInjected: { quoters, tokenFetcher, permit2Fetcher, rpcUrlMap },
+      containerInjected: { quoters, tokenFetcher, permit2Fetcher, syntheticStatusProvider, rpcUrlMap },
     } = params;
 
     const startTime = Date.now();
@@ -95,7 +95,13 @@ export class QuoteHandler extends APIGLambdaHandler<
       quoteRequests = removeDutchRequests(quoteRequests);
     }
 
-    const contextHandler = new QuoteContextManager(parseQuoteContexts(quoteRequests, permit2Fetcher, provider));
+    const contextHandler = new QuoteContextManager(
+      parseQuoteContexts(quoteRequests, {
+        rpcProvider: provider,
+        permit2Fetcher,
+        syntheticStatusProvider,
+      })
+    );
     const requests = contextHandler.getRequests();
     log.info({ requests }, 'requests');
 

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -8,7 +8,7 @@ import { RoutingType } from '../../constants';
 import { QuoteRequestBodyJSON } from '../../entities';
 import { Permit2Fetcher } from '../../fetchers/Permit2Fetcher';
 import { TokenFetcher } from '../../fetchers/TokenFetcher';
-import { Quoter, RfqQuoter, RoutingApiQuoter } from '../../providers/quoters';
+import { Quoter, RfqQuoter, RoutingApiQuoter, SyntheticStatusProvider } from '../../providers';
 import { setGlobalLogger } from '../../util/log';
 import { setGlobalMetrics } from '../../util/metrics';
 import { checkDefined } from '../../util/preconditions';
@@ -22,6 +22,7 @@ export interface ContainerInjected {
   quoters: QuoterByRoutingType;
   tokenFetcher: TokenFetcher;
   permit2Fetcher: Permit2Fetcher;
+  syntheticStatusProvider: SyntheticStatusProvider;
   rpcUrlMap: Map<ChainId, string>;
 }
 
@@ -54,6 +55,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, ApiRInj, Quote
       rpcUrlMap,
       tokenFetcher: new TokenFetcher(),
       permit2Fetcher: new Permit2Fetcher(rpcUrlMap),
+      syntheticStatusProvider: new SyntheticStatusProvider(paramApiUrl, paramApiKey),
     };
   }
 

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -8,7 +8,13 @@ import { RoutingType } from '../../constants';
 import { QuoteRequestBodyJSON } from '../../entities';
 import { Permit2Fetcher } from '../../fetchers/Permit2Fetcher';
 import { TokenFetcher } from '../../fetchers/TokenFetcher';
-import { Quoter, RfqQuoter, RoutingApiQuoter, SyntheticStatusProvider } from '../../providers';
+import {
+  Quoter,
+  RfqQuoter,
+  RoutingApiQuoter,
+  SyntheticStatusProvider,
+  UPASyntheticStatusProvider,
+} from '../../providers';
 import { setGlobalLogger } from '../../util/log';
 import { setGlobalMetrics } from '../../util/metrics';
 import { checkDefined } from '../../util/preconditions';
@@ -55,7 +61,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, ApiRInj, Quote
       rpcUrlMap,
       tokenFetcher: new TokenFetcher(),
       permit2Fetcher: new Permit2Fetcher(rpcUrlMap),
-      syntheticStatusProvider: new SyntheticStatusProvider(paramApiUrl, paramApiKey),
+      syntheticStatusProvider: new UPASyntheticStatusProvider(paramApiUrl, paramApiKey),
     };
   }
 

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -45,6 +45,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, ApiRInj, Quote
     const routingApiUrl = checkDefined(process.env.ROUTING_API_URL, 'ROUTING_API_URL is not defined');
     const routingApiKey = checkDefined(process.env.ROUTING_API_KEY, 'ROUTING_API_KEY is not defined');
     const paramApiKey = checkDefined(process.env.PARAMETERIZATION_API_KEY, 'PARAMETERIZATION_API_KEY is not defined');
+    const synthSwitchApiKey = checkDefined(process.env.SYNTH_SWITCH_API_KEY, 'SYNTH_SWITCH_API_KEY is not defined');
     const serviceUrl = checkDefined(process.env.SERVICE_URL, 'SERVICE_URL is not defined');
 
     const rpcUrlMap = new Map<ChainId, string>();
@@ -61,7 +62,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, ApiRInj, Quote
       rpcUrlMap,
       tokenFetcher: new TokenFetcher(),
       permit2Fetcher: new Permit2Fetcher(rpcUrlMap),
-      syntheticStatusProvider: new UPASyntheticStatusProvider(paramApiUrl, paramApiKey),
+      syntheticStatusProvider: new UPASyntheticStatusProvider(paramApiUrl, synthSwitchApiKey),
     };
   }
 

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,0 +1,2 @@
+export * from './quoters';
+export * from './syntheticStatusProvider';

--- a/lib/providers/syntheticStatusProvider.ts
+++ b/lib/providers/syntheticStatusProvider.ts
@@ -1,0 +1,35 @@
+import querystring from 'querystring';
+import { QuoteRequestInfo } from '../entities';
+import axios from './quoters/helpers';
+
+export type SyntheticStatus = {
+  useSynthetic: boolean;
+};
+
+export interface SyntheticStatusProvider {
+  getStatus(quoteRequest: QuoteRequestInfo): Promise<SyntheticStatus>;
+}
+
+// fetches synthetic status from UniswapX Param API
+// TODO: add caching wrapper? Probably dont want to cache too aggressively
+// at risk of missing an important switch-off
+export class UPASyntheticStatusProvider implements SyntheticStatusProvider {
+  constructor(private upaUrl: string, private paramApiKey: string) {}
+
+  async getStatus(quoteRequest: QuoteRequestInfo): Promise<SyntheticStatus> {
+    const { tokenIn, tokenOut, amount } = quoteRequest;
+    const result = await axios.get(
+      `${this.upaUrl}synthetic-quote/enabled?` +
+        querystring.stringify({
+          tokenIn,
+          tokenOut,
+          amount: amount.toString(),
+        }),
+      { headers: { 'x-api-key': this.paramApiKey } }
+    );
+
+    return {
+      useSynthetic: result.data.useSynthetic,
+    };
+  }
+}

--- a/lib/providers/syntheticStatusProvider.ts
+++ b/lib/providers/syntheticStatusProvider.ts
@@ -1,5 +1,5 @@
-import querystring from 'querystring';
 import { TradeType } from '@uniswap/sdk-core';
+import querystring from 'querystring';
 import { QuoteRequestInfo } from '../entities';
 import axios from './quoters/helpers';
 

--- a/lib/providers/syntheticStatusProvider.ts
+++ b/lib/providers/syntheticStatusProvider.ts
@@ -1,4 +1,5 @@
 import querystring from 'querystring';
+import { TradeType } from '@uniswap/sdk-core';
 import { QuoteRequestInfo } from '../entities';
 import axios from './quoters/helpers';
 
@@ -17,13 +18,16 @@ export class UPASyntheticStatusProvider implements SyntheticStatusProvider {
   constructor(private upaUrl: string, private paramApiKey: string) {}
 
   async getStatus(quoteRequest: QuoteRequestInfo): Promise<SyntheticStatus> {
-    const { tokenIn, tokenOut, amount } = quoteRequest;
+    const { tokenIn, tokenInChainId, tokenOut, tokenOutChainId, amount, type } = quoteRequest;
     const result = await axios.get(
-      `${this.upaUrl}synthetic-quote/enabled?` +
+      `${this.upaUrl}synthetic-switch/enabled?` +
         querystring.stringify({
           tokenIn,
+          tokenInChainId,
           tokenOut,
+          tokenOutChainId,
           amount: amount.toString(),
+          type: TradeType[type],
         }),
       { headers: { 'x-api-key': this.paramApiKey } }
     );

--- a/lib/providers/syntheticStatusProvider.ts
+++ b/lib/providers/syntheticStatusProvider.ts
@@ -1,6 +1,7 @@
 import { TradeType } from '@uniswap/sdk-core';
 import querystring from 'querystring';
 import { QuoteRequestInfo } from '../entities';
+import { log } from '../util/log';
 import axios from './quoters/helpers';
 
 export type SyntheticStatus = {
@@ -19,21 +20,29 @@ export class UPASyntheticStatusProvider implements SyntheticStatusProvider {
 
   async getStatus(quoteRequest: QuoteRequestInfo): Promise<SyntheticStatus> {
     const { tokenIn, tokenInChainId, tokenOut, tokenOutChainId, amount, type } = quoteRequest;
-    const result = await axios.get(
-      `${this.upaUrl}synthetic-switch/enabled?` +
-        querystring.stringify({
-          tokenIn,
-          tokenInChainId,
-          tokenOut,
-          tokenOutChainId,
-          amount: amount.toString(),
-          type: TradeType[type],
-        }),
-      { headers: { 'x-api-key': this.paramApiKey } }
-    );
 
-    return {
-      useSynthetic: result.data.useSynthetic,
-    };
+    try {
+      const result = await axios.get(
+        `${this.upaUrl}synthetic-switch/enabled?` +
+          querystring.stringify({
+            tokenIn,
+            tokenInChainId,
+            tokenOut,
+            tokenOutChainId,
+            amount: amount.toString(),
+            type: TradeType[type],
+          }),
+        { headers: { 'x-api-key': this.paramApiKey } }
+      );
+
+      return {
+        useSynthetic: result.data.useSynthetic,
+      };
+    } catch (e) {
+      log.error('Error fetching synthetic status from UPA', e);
+      return {
+        useSynthetic: false,
+      };
+    }
   }
 }

--- a/test/integ/quote-gouda.test.ts
+++ b/test/integ/quote-gouda.test.ts
@@ -289,7 +289,10 @@ describe('quoteUniswapX', function () {
               CurrencyAmount.fromRawAmount(USDT_MAINNET, order.info.outputs[0].startAmount.toString())
             );
           } else {
-            expect(tokenOutAfter.subtract(tokenOutBefore).greaterThan(10_000) || tokenOutAfter.subtract(tokenOutBefore).equalTo(10_000)).to.be.true;
+            expect(
+              tokenOutAfter.subtract(tokenOutBefore).greaterThan(10_000) ||
+                tokenOutAfter.subtract(tokenOutBefore).equalTo(10_000)
+            ).to.be.true;
             checkQuoteToken(
               tokenInBefore,
               tokenInAfter,
@@ -349,7 +352,10 @@ describe('quoteUniswapX', function () {
               CurrencyAmount.fromRawAmount(USDT_MAINNET, order.info.outputs[0].startAmount.toString())
             );
           } else {
-            expect(tokenOutAfter.subtract(tokenOutBefore).greaterThan(10_000) || tokenOutAfter.subtract(tokenOutBefore).equalTo(10_000)).to.be.true;
+            expect(
+              tokenOutAfter.subtract(tokenOutBefore).greaterThan(10_000) ||
+                tokenOutAfter.subtract(tokenOutBefore).equalTo(10_000)
+            ).to.be.true;
             checkQuoteToken(
               tokenInBefore,
               tokenInAfter,
@@ -442,7 +448,10 @@ describe('quoteUniswapX', function () {
               CurrencyAmount.fromRawAmount(UNI_MAINNET, order.info.outputs[0].startAmount.toString())
             );
           } else {
-            expect(tokenOutAfter.subtract(tokenOutBefore).greaterThan(1_000) || tokenOutAfter.subtract(tokenOutBefore).equalTo(1_000)).to.be.true;
+            expect(
+              tokenOutAfter.subtract(tokenOutBefore).greaterThan(1_000) ||
+                tokenOutAfter.subtract(tokenOutBefore).equalTo(1_000)
+            ).to.be.true;
             checkQuoteToken(
               tokenInBefore,
               tokenInAfter,

--- a/test/unit/lib/entities/context/ClassicQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/ClassicQuoteContext.test.ts
@@ -32,7 +32,7 @@ describe('ClassicQuoteContext', () => {
   describe('dependencies', () => {
     it('returns only request dependency', () => {
       const permit2Fetcher = permit2FetcherMock(PERMIT_DETAILS);
-      const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC, permit2Fetcher);
+      const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC, { permit2Fetcher });
       expect(context.dependencies()).toEqual([QUOTE_REQUEST_CLASSIC]);
     });
   });
@@ -40,13 +40,13 @@ describe('ClassicQuoteContext', () => {
   describe('resolve', () => {
     it('returns null if no quotes given', async () => {
       const permit2Fetcher = permit2FetcherMock(PERMIT_DETAILS);
-      const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC, permit2Fetcher);
+      const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC, { permit2Fetcher });
       expect(await context.resolve({})).toEqual(null);
     });
 
     it('still returns quote if too many dependencies given', async () => {
       const permit2Fetcher = permit2FetcherMock(PERMIT_DETAILS);
-      const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC, permit2Fetcher);
+      const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC, { permit2Fetcher });
       expect(
         await context.resolve({
           [QUOTE_REQUEST_CLASSIC.key()]: CLASSIC_QUOTE_EXACT_IN_BETTER,
@@ -57,7 +57,7 @@ describe('ClassicQuoteContext', () => {
 
     it('returns quote', async () => {
       const permit2Fetcher = permit2FetcherMock(PERMIT_DETAILS);
-      const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC, permit2Fetcher);
+      const context = new ClassicQuoteContext(logger, QUOTE_REQUEST_CLASSIC, { permit2Fetcher });
       expect(
         await context.resolve({
           [QUOTE_REQUEST_CLASSIC.key()]: CLASSIC_QUOTE_EXACT_IN_BETTER,

--- a/test/unit/lib/entities/context/DutchQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/DutchQuoteContext.test.ts
@@ -18,6 +18,7 @@ import {
   TOKEN_OUT,
   USDC_ADDRESS,
 } from '../../../../constants';
+import { SyntheticStatusProvider } from '../../../../../lib/providers';
 import {
   BASE_REQUEST_INFO_EXACT_IN,
   createClassicQuote,
@@ -34,6 +35,15 @@ describe('DutchQuoteContext', () => {
   let provider: any;
 
   const OLD_ENV = process.env;
+
+  const SyntheticStatusProviderMock = (useSynthetic: boolean): SyntheticStatusProvider => {
+    const provider = {
+      getStatus: jest.fn(),
+    };
+
+    provider.getStatus.mockResolvedValue({ useSynthetic });
+    return provider as unknown as SyntheticStatusProvider;
+  };
 
   beforeAll(() => {
     jest.resetModules(); // Most important - it clears the cache
@@ -55,9 +65,16 @@ describe('DutchQuoteContext', () => {
     process.env = OLD_ENV; // Restore old environment
   });
 
+  function makeProviders(useSynthetic: boolean) {
+    return {
+      rpcProvider: provider,
+      syntheticStatusProvider: SyntheticStatusProviderMock(useSynthetic),
+    };
+  }
+
   describe('dependencies', () => {
     it('returns expected dependencies when output is weth', () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       const deps = context.dependencies();
       expect(deps.length).toEqual(2);
       // first is base
@@ -71,7 +88,7 @@ describe('DutchQuoteContext', () => {
       const request = makeDutchRequest({
         tokenOut: '0x1111111111111111111111111111111111111111',
       });
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const deps = context.dependencies();
       expect(deps.length).toEqual(3);
       // first is base
@@ -88,12 +105,12 @@ describe('DutchQuoteContext', () => {
 
   describe('resolve', () => {
     it('returns null if no dependencies given', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       expect(await context.resolve({})).toEqual(null);
     });
 
     it('returns null if quote key is not set properly', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       expect(
         await context.resolve({
           wrong: DL_QUOTE_EXACT_IN_BETTER,
@@ -102,7 +119,7 @@ describe('DutchQuoteContext', () => {
     });
 
     it('returns main quote if others are null', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: AMOUNT, filler }, 'EXACT_INPUT');
       const quote = await context.resolve({
@@ -113,7 +130,7 @@ describe('DutchQuoteContext', () => {
     });
 
     it('returns null if quotes have 0 amountOut', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: '0', filler }, 'EXACT_INPUT');
       expect(
@@ -124,7 +141,7 @@ describe('DutchQuoteContext', () => {
     });
 
     it('returns null if tokenIn is not in tokenlist', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       const rfqQuote = createDutchQuote(
         { tokenIn: '0x0000000000000000000000000000000000000000', amountOut: '1' },
         'EXACT_INPUT'
@@ -136,7 +153,7 @@ describe('DutchQuoteContext', () => {
     });
 
     it('returns null if tokenOut is not in tokenlist', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       const rfqQuote = createDutchQuote(
         { tokenOut: '0x0000000000000000000000000000000000000000', amountOut: '1' },
         'EXACT_INPUT'
@@ -147,9 +164,9 @@ describe('DutchQuoteContext', () => {
       expect(quote).toBeNull();
     });
 
-    it('uses synthetic if better', async () => {
+    it('uses synthetic if better with useSyntheticQuotes=true and switch=false', async () => {
       const request = makeDutchRequest({}, { useSyntheticQuotes: true });
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: '1', filler }, 'EXACT_INPUT');
       expect(rfqQuote.filler).toEqual(filler);
@@ -174,8 +191,85 @@ describe('DutchQuoteContext', () => {
       );
     });
 
+    it('uses synthetic if better with useSyntheticQuotes=true and switch=true', async () => {
+      const request = makeDutchRequest({}, { useSyntheticQuotes: true });
+      const context = new DutchQuoteContext(logger, request, makeProviders(true));
+      const filler = '0x1111111111111111111111111111111111111111';
+      const rfqQuote = createDutchQuote({ amountOut: '1', filler }, 'EXACT_INPUT');
+      expect(rfqQuote.filler).toEqual(filler);
+      const classicQuote = createClassicQuote(
+        { quote: '10000000000', quoteGasAdjusted: '9999000000' },
+        { type: 'EXACT_INPUT' }
+      );
+      context.dependencies();
+
+      const quote = await context.resolve({
+        [context.requestKey]: rfqQuote,
+        [context.classicKey]: classicQuote,
+        [context.routeToNativeKey]: classicQuote,
+      });
+      expect(quote?.routingType).toEqual(RoutingType.DUTCH_LIMIT);
+      expect((quote?.toJSON() as DutchQuoteDataJSON).orderInfo.exclusiveFiller).toEqual(
+        '0x0000000000000000000000000000000000000000'
+      );
+      // Synthetic starts at quoteGasAdjusted + 1bp
+      expect(quote?.amountOut.toString()).toEqual(
+        BigNumber.from(9999000000).mul(DutchQuote.amountOutImprovementExactIn).div(10000).toString()
+      );
+    });
+
+    it('uses synthetic if better with useSyntheticQuotes=false and switch=true', async () => {
+      const request = makeDutchRequest({}, { useSyntheticQuotes: false });
+      const context = new DutchQuoteContext(logger, request, makeProviders(true));
+      const filler = '0x1111111111111111111111111111111111111111';
+      const rfqQuote = createDutchQuote({ amountOut: '1', filler }, 'EXACT_INPUT');
+      expect(rfqQuote.filler).toEqual(filler);
+      const classicQuote = createClassicQuote(
+        { quote: '10000000000', quoteGasAdjusted: '9999000000' },
+        { type: 'EXACT_INPUT' }
+      );
+      context.dependencies();
+
+      const quote = await context.resolve({
+        [context.requestKey]: rfqQuote,
+        [context.classicKey]: classicQuote,
+        [context.routeToNativeKey]: classicQuote,
+      });
+      expect(quote?.routingType).toEqual(RoutingType.DUTCH_LIMIT);
+      expect((quote?.toJSON() as DutchQuoteDataJSON).orderInfo.exclusiveFiller).toEqual(
+        '0x0000000000000000000000000000000000000000'
+      );
+      // Synthetic starts at quoteGasAdjusted + 1bp
+      expect(quote?.amountOut.toString()).toEqual(
+        BigNumber.from(9999000000).mul(DutchQuote.amountOutImprovementExactIn).div(10000).toString()
+      );
+    });
+
+    it.only('does not use synthetic if better with useSyntheticQuotes=false and switch=false', async () => {
+      const request = makeDutchRequest({}, { useSyntheticQuotes: false });
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
+      const filler = '0x1111111111111111111111111111111111111111';
+      const rfqQuote = createDutchQuote({ amountOut: '9999000009', filler }, 'EXACT_INPUT');
+      expect(rfqQuote.filler).toEqual(filler);
+      const classicQuote = createClassicQuote(
+        { quote: '10000000000', quoteGasAdjusted: '9999000000' },
+        { type: 'EXACT_INPUT' }
+      );
+      context.dependencies();
+
+      const quote = await context.resolve({
+        [context.requestKey]: rfqQuote,
+        [context.classicKey]: classicQuote,
+        [context.routeToNativeKey]: classicQuote,
+      });
+      expect(quote?.routingType).toEqual(RoutingType.DUTCH_LIMIT);
+      expect((quote?.toJSON() as DutchQuoteDataJSON).orderInfo.exclusiveFiller).toEqual(
+        filler
+      );
+    });
+
     it('uses synthetic if rfq quote is at least 300% better than clasic; EXACT_IN', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: '400000000', filler }, 'EXACT_INPUT');
       const classicQuote = createClassicQuote(
@@ -197,7 +291,7 @@ describe('DutchQuoteContext', () => {
 
     it('uses synthetic if rfq quote is at least 300% better than clasic; EXACT_OUT', async () => {
       const request = makeDutchRequest({ type: 'EXACT_OUTPUT' }, { useSyntheticQuotes: true });
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountIn: '100000000', filler }, 'EXACT_OUTPUT');
       const classicQuote = createClassicQuote(
@@ -219,7 +313,7 @@ describe('DutchQuoteContext', () => {
 
     it('skips UniswapX if rfq quote is at least 300% better than clasic; EXACT_IN, skipSynthetic', async () => {
       const request = makeDutchRequest({}, { useSyntheticQuotes: false });
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: '400000000', filler }, 'EXACT_INPUT');
       const classicQuote = createClassicQuote(
@@ -237,7 +331,7 @@ describe('DutchQuoteContext', () => {
 
     it('skips UniswapX if rfq quote is at least 300% better than clasic; EXACT_OUT, skipSynthetic', async () => {
       const request = makeDutchRequest({ type: 'EXACT_OUTPUT' }, { useSyntheticQuotes: false });
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountIn: '100000000', filler }, 'EXACT_OUTPUT');
       const classicQuote = createClassicQuote(
@@ -253,7 +347,7 @@ describe('DutchQuoteContext', () => {
       ).toEqual(null);
     });
     it('filters out zero amountOut quotes in favor of others', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: '0', filler }, 'EXACT_INPUT');
       expect(rfqQuote.filler).toEqual(filler);
@@ -280,7 +374,7 @@ describe('DutchQuoteContext', () => {
 
     it('skips synthetic if useSyntheticQuotes = false', async () => {
       const request = makeDutchRequest({}, { useSyntheticQuotes: false });
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: '1000000000000000000', filler }, 'EXACT_INPUT');
       expect(rfqQuote.filler).toEqual(filler);
@@ -303,7 +397,7 @@ describe('DutchQuoteContext', () => {
       const request = makeDutchRequest({
         tokenOut: '0x1111111111111111111111111111111111111111',
       });
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: '1000000000000000000', filler }, 'EXACT_INPUT');
       expect(rfqQuote.filler).toEqual(filler);
@@ -326,7 +420,7 @@ describe('DutchQuoteContext', () => {
       const request = makeDutchRequest({
         tokenOut: '0x1111111111111111111111111111111111111111',
       });
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: '1', filler }, 'EXACT_INPUT');
       expect(rfqQuote.filler).toEqual(filler);
@@ -345,7 +439,7 @@ describe('DutchQuoteContext', () => {
 
     it('keeps synthetic if output is weth', async () => {
       const request = makeDutchRequest({}, { useSyntheticQuotes: true });
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const native = WRAPPED_NATIVE_CURRENCY[ID_TO_CHAIN_ID(1)].address;
       const rfqQuote = createDutchQuote({ amountOut: '1', tokenOut: native, filler }, 'EXACT_INPUT');
@@ -370,7 +464,7 @@ describe('DutchQuoteContext', () => {
     });
 
     it('returns no DL quotes if classic provided does not meet gas threshold', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       context.dependencies();
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: AMOUNT, filler }, 'EXACT_INPUT');
@@ -389,7 +483,7 @@ describe('DutchQuoteContext', () => {
     });
 
     it('still returns DL rfq quote if classic is not provided', async () => {
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
       context.dependencies();
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuote({ amountOut: AMOUNT, filler }, 'EXACT_INPUT');
@@ -433,7 +527,7 @@ describe('DutchQuoteContext', () => {
         };
       });
 
-      let context = new DutchQuoteContext(logger, request, provider);
+      let context = new DutchQuoteContext(logger, request, makeProviders(false));
       context.dependencies();
 
       const nonApprovedQuote = await context.resolve({
@@ -448,7 +542,7 @@ describe('DutchQuoteContext', () => {
         };
       });
 
-      context = new DutchQuoteContext(logger, request, provider);
+      context = new DutchQuoteContext(logger, request, makeProviders(false));
       context.dependencies();
 
       const approvedQuote = await context.resolve({
@@ -490,7 +584,7 @@ describe('DutchQuoteContext', () => {
   describe('hasOrderSize', () => {
     describe('exactIn', () => {
       it('returns true if quote == quoteGasAdjusted', async () => {
-        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
         const amountOut = ethers.utils.parseEther('1');
         const classicQuote = createClassicQuote(
           { quote: amountOut.toString(), quoteGasAdjusted: amountOut.toString() },
@@ -501,7 +595,7 @@ describe('DutchQuoteContext', () => {
       });
 
       it('returns true if amountOut * 5% == gas used', async () => {
-        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
 
         const amountOut = ethers.utils.parseEther('1');
         const fivePercent = amountOut.mul(5).div(100);
@@ -515,7 +609,7 @@ describe('DutchQuoteContext', () => {
       });
 
       it('returns false if amountOut * 55% == gas used', async () => {
-        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
 
         const amountOut = ethers.utils.parseEther('1');
         const gas = amountOut.mul(55).div(100);
@@ -531,7 +625,7 @@ describe('DutchQuoteContext', () => {
 
     describe('exactOut', () => {
       it('returns true if amountIn * 5% == gas used', async () => {
-        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
 
         const amountIn = ethers.utils.parseEther('1');
         const fivePercent = amountIn.mul(5).div(100);
@@ -545,7 +639,7 @@ describe('DutchQuoteContext', () => {
       });
 
       it('returns false if amountIn * 55% == gas used', async () => {
-        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, provider);
+        const context = new DutchQuoteContext(logger, QUOTE_REQUEST_DL, makeProviders(false));
 
         const amountIn = ethers.utils.parseEther('1');
         const gas = amountIn.mul(55).div(100);
@@ -574,7 +668,7 @@ describe('DutchQuoteContext', () => {
         useUniswapX: true,
       };
       const QUOTE_REQUEST_ELIGIBLE_TOKENS = makeDutchRequest({}, { useSyntheticQuotes: true }, baseRequest);
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_ELIGIBLE_TOKENS, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_ELIGIBLE_TOKENS, makeProviders(false));
       expect(context.hasSyntheticEligibleTokens()).toEqual(true);
     });
 
@@ -591,7 +685,7 @@ describe('DutchQuoteContext', () => {
         useUniswapX: true,
       };
       const QUOTE_REQUEST_INELIGIBLE_TOKEN = makeDutchRequest({}, { useSyntheticQuotes: true }, baseRequest);
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_INELIGIBLE_TOKEN, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_INELIGIBLE_TOKEN, makeProviders(false));
       expect(context.hasSyntheticEligibleTokens()).toEqual(false);
     });
 
@@ -608,7 +702,7 @@ describe('DutchQuoteContext', () => {
         useUniswapX: true,
       };
       const QUOTE_REQUEST_INELIGIBLE_TOKEN = makeDutchRequest({}, { useSyntheticQuotes: true }, baseRequest);
-      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_INELIGIBLE_TOKEN, provider);
+      const context = new DutchQuoteContext(logger, QUOTE_REQUEST_INELIGIBLE_TOKEN, makeProviders(false));
       expect(context.hasSyntheticEligibleTokens()).toEqual(false);
     });
   });
@@ -620,7 +714,7 @@ describe('DutchQuoteContext', () => {
         { useSyntheticQuotes: true },
         { ...BASE_REQUEST_INFO_EXACT_IN, tokenOut: USDC_ADDRESS }
       );
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuoteWithRequest(
         { amountOut: '1', filler, tokenOut: USDC_ADDRESS },
@@ -654,7 +748,7 @@ describe('DutchQuoteContext', () => {
         { useSyntheticQuotes: true },
         { ...BASE_REQUEST_INFO_EXACT_IN, tokenOut: USDC_ADDRESS }
       );
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuoteWithRequest(
         { amountOut: '1', filler, tokenOut: USDC_ADDRESS },
@@ -680,7 +774,7 @@ describe('DutchQuoteContext', () => {
         { useSyntheticQuotes: true },
         { ...BASE_REQUEST_INFO_EXACT_IN, tokenOut: NATIVE_ADDRESS }
       );
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuoteWithRequest(
         { amountOut: '1', filler, tokenOut: NATIVE_ADDRESS },
@@ -713,7 +807,7 @@ describe('DutchQuoteContext', () => {
         { useSyntheticQuotes: true },
         { ...BASE_REQUEST_INFO_EXACT_IN, tokenOut: WRAPPED_NATIVE_CURRENCY[ID_TO_CHAIN_ID(CHAIN_OUT_ID)].address }
       );
-      const context = new DutchQuoteContext(logger, request, provider);
+      const context = new DutchQuoteContext(logger, request, makeProviders(false));
       const filler = '0x1111111111111111111111111111111111111111';
       const rfqQuote = createDutchQuoteWithRequest(
         { amountOut: '1', filler, tokenOut: WRAPPED_NATIVE_CURRENCY[ID_TO_CHAIN_ID(CHAIN_OUT_ID)].address },

--- a/test/unit/lib/entities/context/DutchQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/DutchQuoteContext.test.ts
@@ -4,6 +4,7 @@ import { BigNumber, ethers } from 'ethers';
 
 import { NATIVE_ADDRESS, RoutingType } from '../../../../../lib/constants';
 import { DutchQuote, DutchQuoteContext, DutchQuoteDataJSON } from '../../../../../lib/entities';
+import { SyntheticStatusProvider } from '../../../../../lib/providers';
 import { Erc20__factory } from '../../../../../lib/types/ext/factories/Erc20__factory';
 import {
   AMOUNT,
@@ -18,7 +19,6 @@ import {
   TOKEN_OUT,
   USDC_ADDRESS,
 } from '../../../../constants';
-import { SyntheticStatusProvider } from '../../../../../lib/providers';
 import {
   BASE_REQUEST_INFO_EXACT_IN,
   createClassicQuote,
@@ -263,9 +263,7 @@ describe('DutchQuoteContext', () => {
         [context.routeToNativeKey]: classicQuote,
       });
       expect(quote?.routingType).toEqual(RoutingType.DUTCH_LIMIT);
-      expect((quote?.toJSON() as DutchQuoteDataJSON).orderInfo.exclusiveFiller).toEqual(
-        filler
-      );
+      expect((quote?.toJSON() as DutchQuoteDataJSON).orderInfo.exclusiveFiller).toEqual(filler);
     });
 
     it('uses synthetic if rfq quote is at least 300% better than clasic; EXACT_IN', async () => {

--- a/test/unit/lib/entities/context/QuoteContextHandler.test.ts
+++ b/test/unit/lib/entities/context/QuoteContextHandler.test.ts
@@ -1,5 +1,6 @@
 import Logger from 'bunyan';
 
+import { RoutingType } from '../../../../../lib/constants';
 import { Quote, QuoteByKey, QuoteContext, QuoteContextManager, QuoteRequest } from '../../../../../lib/entities';
 import {
   CLASSIC_QUOTE_EXACT_IN_BETTER,
@@ -10,7 +11,6 @@ import {
   QUOTE_REQUEST_DL_EXACT_OUT,
   QUOTE_REQUEST_DL_NATIVE_IN,
 } from '../../../../utils/fixtures';
-import { RoutingType } from '../../../../../lib/constants';
 
 class MockQuoteContext implements QuoteContext {
   routingType: RoutingType.CLASSIC;

--- a/test/unit/lib/handlers/quote/handler.test.ts
+++ b/test/unit/lib/handlers/quote/handler.test.ts
@@ -94,7 +94,7 @@ describe('QuoteHandler', () => {
       quoters: QuoterByRoutingType,
       tokenFetcher: TokenFetcher,
       permit2Fetcher: Permit2Fetcher,
-      syntheticStatusProvider: SyntheticStatusProvider,
+      syntheticStatusProvider: SyntheticStatusProvider
     ): Promise<ApiInjector<ContainerInjected, ApiRInj, QuoteRequestBodyJSON, void>> =>
       new Promise((resolve) =>
         resolve({
@@ -119,7 +119,7 @@ describe('QuoteHandler', () => {
       quoters: QuoterByRoutingType,
       tokenFetcher: TokenFetcher,
       permit2Fetcher: Permit2Fetcher,
-      syntheticStatusProvider: SyntheticStatusProvider,
+      syntheticStatusProvider: SyntheticStatusProvider
     ) => new QuoteHandler('quote', injectorPromiseMock(quoters, tokenFetcher, permit2Fetcher, syntheticStatusProvider));
 
     const RfqQuoterMock = (dlQuote: DutchQuote): Quoter => {
@@ -659,10 +659,12 @@ describe('QuoteHandler', () => {
         const permit2Fetcher = Permit2FetcherMock(PERMIT_DETAILS);
         const syntheticStatusProvider = SyntheticStatusProviderMock(false);
 
-        const res = await getQuoteHandler(quoters, tokenFetcher, permit2Fetcher, syntheticStatusProvider).parseAndValidateRequest(
-          event,
-          logger as unknown as Logger
-        );
+        const res = await getQuoteHandler(
+          quoters,
+          tokenFetcher,
+          permit2Fetcher,
+          syntheticStatusProvider
+        ).parseAndValidateRequest(event, logger as unknown as Logger);
         expect(res.state).toBe('valid');
       });
 
@@ -678,10 +680,12 @@ describe('QuoteHandler', () => {
         const permit2Fetcher = Permit2FetcherMock(PERMIT_DETAILS);
         const syntheticStatusProvider = SyntheticStatusProviderMock(false);
 
-        const res = await getQuoteHandler(quoters, tokenFetcher, permit2Fetcher, syntheticStatusProvider).parseAndValidateRequest(
-          event,
-          logger as unknown as Logger
-        );
+        const res = await getQuoteHandler(
+          quoters,
+          tokenFetcher,
+          permit2Fetcher,
+          syntheticStatusProvider
+        ).parseAndValidateRequest(event, logger as unknown as Logger);
         expect(res.state).toBe('invalid');
       });
 
@@ -694,10 +698,12 @@ describe('QuoteHandler', () => {
         const permit2Fetcher = Permit2FetcherMock(PERMIT_DETAILS);
         const syntheticStatusProvider = SyntheticStatusProviderMock(false);
 
-        const res = await getQuoteHandler(quoters, tokenFetcher, permit2Fetcher, syntheticStatusProvider).parseAndValidateRequest(
-          event,
-          logger as unknown as Logger
-        );
+        const res = await getQuoteHandler(
+          quoters,
+          tokenFetcher,
+          permit2Fetcher,
+          syntheticStatusProvider
+        ).parseAndValidateRequest(event, logger as unknown as Logger);
         expect(res.state).toBe('valid');
       });
     });

--- a/test/unit/lib/handlers/quote/schema.test.ts
+++ b/test/unit/lib/handlers/quote/schema.test.ts
@@ -266,11 +266,11 @@ describe('Post quote request validation', () => {
         },
         {
           ...DL_CONFIG_JSON,
-          auctionPeriodSeconds: -1
+          auctionPeriodSeconds: -1,
         },
       ],
     });
     expect(error).toBeDefined();
-    expect(error?.message).toEqual('\"configs[1]\" does not match any of the allowed types');
+    expect(error?.message).toEqual('"configs[1]" does not match any of the allowed types');
   });
 });


### PR DESCRIPTION
This commit adds a dynamic switch-on for synthetic UniswapX quotes using
the UPA enabled endpoint. It will automatically consider or reject
synthetic quotes depending on the response from this endpoint
