### PR TITLE
Expose enableFeeOnTransferFeeFetching post request field

### DIFF
--- a/lib/entities/request/ClassicRequest.ts
+++ b/lib/entities/request/ClassicRequest.ts
@@ -24,6 +24,7 @@ export interface ClassicConfig {
   debugRoutingConfig?: string;
   unicornSecret?: string;
   quoteSpeed?: string;
+  enableFeeOnTransferFeeFetching?: boolean;
 }
 
 export interface ClassicConfigJSON extends Omit<ClassicConfig, 'protocols' | 'permitAmount'> {

--- a/lib/providers/quoters/RoutingApiQuoter.ts
+++ b/lib/providers/quoters/RoutingApiQuoter.ts
@@ -106,6 +106,7 @@ export class RoutingApiQuoter implements Quoter {
         // expect web/mobile to send it for the 1st fast quote,
         // otherwise default not to send it
         ...(config.quoteSpeed !== undefined && { quoteSpeed: config.quoteSpeed }),
+        ...(config.enableFeeOnTransferFeeFetching !== undefined && { enableFeeOnTransferFeeFetching: config.enableFeeOnTransferFeeFetching}),
       })
     );
   }

--- a/lib/util/validator.ts
+++ b/lib/util/validator.ts
@@ -93,6 +93,7 @@ export class FieldValidator {
     slippageTolerance: FieldValidator.slippageTolerance.optional(),
     algorithm: FieldValidator.algorithm.optional(),
     quoteSpeed: FieldValidator.quoteSpeed.optional(),
+    enableFeeOnTransferFeeFetching: Joi.boolean().optional(),
   });
 
   public static readonly dutchLimitConfig = Joi.object({


### PR DESCRIPTION
Interface already fetches fee-on-transfer tax and shave off the quote amount. We need to protect smart-order-router fee-on-transfer tax [feature](https://github.com/Uniswap/smart-order-router/pull/395/files) under a feature flag, so that interface doesn't double FOT tax.

Routing-api corresponding PR https://github.com/Uniswap/routing-api/pull/361

Tested via:

```
curl 'https://ggy7t0yp57.execute-api.us-east-2.amazonaws.com/prod/quote' \
  --data-raw '{
   "tokenInChainId":1,
   "tokenIn":"0x0D0A1767da735F725f41c4315E072c63Dbc6ab3D",
   "tokenOutChainId":1,
   "tokenOut":"0xab98093c7232e98a47d7270ce0c1c2106f61c73b",
   "amount":"1000000000000000000",
   "type":"EXACT_INPUT",
   "configs":[
      {
         "protocols":[
            "V2",
            "V3",
            "MIXED"
         ],
         "routingType":"CLASSIC",
         "unicornSecret":"MASKED",
         "debugRoutingConfig": "{\"debugRouting\":true}",
         "enableFeeOnTransferFeeFetching": true
       }
   ]
}'
```

Can see `enableFeeOnTransferFeeFetching` passing through routing-api until smart-order-router in personal AWS [logging insights](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-10800~timeType~'RELATIVE~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20like*20*2758fba2b3-9eb9-4a5d-b6d2-9ed251e3db9b*27*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2020~queryId~'a9427a2dbb3284d-75b3809d-44b75a-e71fd81f-824017d25d7a8246ccf8b2e4~source~(~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-jS6GXdZ1EYtE~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-pOSkckAzB5N6~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-xxMl8mSwRJxq~'*2faws*2flambda*2fRoutingAPIStack-RoutingLamb-RoutingLambda2C4DF0900-YwgyYPOqKbbD))):
<img width="1182" alt="Screenshot 2023-09-08 at 12 37 07 PM" src="https://github.com/Uniswap/unified-routing-api/assets/91580504/f0ef81ef-1a79-44ff-a1bd-dd58a7079e4e">
