### PR TITLE
feat: add simulation flag for X comparisons

### DIFF
--- a/lib/entities/context/DutchQuoteContext.ts
+++ b/lib/entities/context/DutchQuoteContext.ts
@@ -64,6 +64,7 @@ export class DutchQuoteContext implements QuoteContext {
   dependencies(): QuoteRequest[] {
     const classicRequest = new ClassicRequest(this.request.info, {
       protocols: [Protocol.MIXED, Protocol.V2, Protocol.V3],
+      simulateFromAddress: this.request.config.swapper,
     });
     this.classicKey = classicRequest.key();
     this.log.info({ classicRequest: classicRequest.info }, 'Adding synthetic classic request');

--- a/lib/entities/context/index.ts
+++ b/lib/entities/context/index.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 
 import { RoutingType } from '../../constants';
-import { ClassicRequest, DutchRequest, Quote, QuoteRequest } from '../../entities';
+import { ClassicConfig, ClassicRequest, DutchRequest, Quote, QuoteRequest } from '../../entities';
 
 import { Permit2Fetcher } from '../../fetchers/Permit2Fetcher';
 import { SyntheticStatusProvider } from '../../providers';
@@ -54,6 +54,8 @@ export class QuoteContextManager {
         const requestKey = request.key();
         if (!requestMap[requestKey]) {
           requestMap[requestKey] = request;
+        } else {
+          requestMap[requestKey] = mergeRequests(requestMap[requestKey], request);
         }
       }
     }
@@ -98,4 +100,20 @@ export function parseQuoteContexts(requests: QuoteRequest[], providers: QuoteCon
         throw new Error(`Unsupported routing type: ${request.routingType}`);
     }
   });
+}
+
+function mergeRequests(base: QuoteRequest, layer: QuoteRequest): QuoteRequest {
+  if (base.routingType === RoutingType.CLASSIC && layer.routingType === RoutingType.CLASSIC) {
+    const layerConfig: ClassicConfig = layer.config as ClassicConfig;
+    const baseConfig: ClassicConfig = base.config as ClassicConfig;
+    const config = Object.assign({}, baseConfig, {
+      // if base does not specify simulation address but layer does, then we add it
+      simulateFromAddress: baseConfig.simulateFromAddress ?? layerConfig.simulateFromAddress,
+      // otherwise defer to base
+    });
+    return Object.assign({}, base, { config });
+  } else {
+    // no special merging logic for dutch, just defer to base
+    return base;
+  }
 }

--- a/lib/entities/context/index.ts
+++ b/lib/entities/context/index.ts
@@ -102,7 +102,7 @@ export function parseQuoteContexts(requests: QuoteRequest[], providers: QuoteCon
   });
 }
 
-function mergeRequests(base: QuoteRequest, layer: QuoteRequest): QuoteRequest {
+export function mergeRequests(base: QuoteRequest, layer: QuoteRequest): QuoteRequest {
   if (base.routingType === RoutingType.CLASSIC && layer.routingType === RoutingType.CLASSIC) {
     const layerConfig: ClassicConfig = layer.config as ClassicConfig;
     const baseConfig: ClassicConfig = base.config as ClassicConfig;

--- a/lib/providers/quoters/RoutingApiQuoter.ts
+++ b/lib/providers/quoters/RoutingApiQuoter.ts
@@ -106,7 +106,9 @@ export class RoutingApiQuoter implements Quoter {
         // expect web/mobile to send it for the 1st fast quote,
         // otherwise default not to send it
         ...(config.quoteSpeed !== undefined && { quoteSpeed: config.quoteSpeed }),
-        ...(config.enableFeeOnTransferFeeFetching !== undefined && { enableFeeOnTransferFeeFetching: config.enableFeeOnTransferFeeFetching}),
+        ...(config.enableFeeOnTransferFeeFetching !== undefined && {
+          enableFeeOnTransferFeeFetching: config.enableFeeOnTransferFeeFetching,
+        }),
       })
     );
   }

--- a/test/unit/lib/entities/context/QuoteContextHandler.test.ts
+++ b/test/unit/lib/entities/context/QuoteContextHandler.test.ts
@@ -124,7 +124,7 @@ describe('QuoteContextManager', () => {
       expect(requests[2]).toMatchObject(QUOTE_REQUEST_DL_EXACT_OUT);
     });
 
-    it.only('merges simulateFromAddress on classic requests', () => {
+    it('merges simulateFromAddress on classic requests', () => {
       const context1 = new MockQuoteContext(QUOTE_REQUEST_DL);
       context1.setDependencies([QUOTE_REQUEST_DL_EXACT_OUT, QUOTE_REQUEST_CLASSIC]);
       const context2 = new MockQuoteContext(QUOTE_REQUEST_CLASSIC);


### PR DESCRIPTION
This commit adds the simulateFromAddress flag to classic quotes when
used as a comparison device for UniswapX quotes. This should make the
gas adjustments more accurate giving us a better view when selecting
quote types for users
