### PR TITLE
feat: orderHash in `/quote` response

### DIFF
--- a/lib/entities/quote/DutchQuote.ts
+++ b/lib/entities/quote/DutchQuote.ts
@@ -28,6 +28,7 @@ export type DutchQuoteDataJSON = {
   quoteId: string;
   requestId: string;
   encodedOrder: string;
+  orderHash: string;
   startTimeBufferSecs: number;
   auctionPeriodSecs: number;
   deadlineBufferSecs: number;
@@ -207,6 +208,7 @@ export class DutchQuote implements IQuote {
       encodedOrder: this.toOrder().serialize(),
       quoteId: this.quoteId,
       requestId: this.requestId,
+      orderHash: this.toOrder().hash(),
       startTimeBufferSecs: this.startTimeBufferSecs,
       auctionPeriodSecs: this.auctionPeriodSecs,
       deadlineBufferSecs: this.deadlineBufferSecs,

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -291,4 +291,5 @@ export const DUTCH_LIMIT_ORDER_JSON = {
   startTimeBufferSecs: 30,
   auctionPeriodSecs: 60,
   slippageTolerance: '0.5',
+  orderHash: '0x8859113385dac928f6e064e6d49539fd94cab32687e1a37592ef6f3192948513'
 };


### PR DESCRIPTION
## Description
- Adds `orderHash` to the response of `/quote` for X quotes
- Allows integrators to later query their order if the do not get a response from when posting a new order
- The change is backwards compatible but we should make sure that we're not breaking the clients --> should not be an issue as they're also ignoring fields like the `encodedOrder`

## Testing
- [X] Unit tests

### Screenshot
<img width="741" alt="Screenshot 2023-10-04 at 6 11 07 PM" src="https://github.com/Uniswap/unified-routing-api/assets/23269489/7004091d-3490-46f1-8b29-5c1643eb183d">
