### PR TITLE
Set portionAmountDecimals to default 0 if undefined

### DIFF
--- a/lib/providers/quoters/RoutingApiQuoter.ts
+++ b/lib/providers/quoters/RoutingApiQuoter.ts
@@ -94,7 +94,7 @@ export class RoutingApiQuoter implements Quoter {
               portionRecipient: portion?.recipient, // important, clients are expected to use this for exact in and exact out swaps
               // TODO: ROUTE-97 - re-evaluate how to properly code up returning portionAmount in case of no fee in URA
               portionAmount: portionAmount?.quotient.toString() ?? '0', // important for exact out, clients are expected to use this for exact out swaps
-              portionAmountDecimals: portionAmount?.toExact(), // important for exact out, clients are expected to use this for exact out swaps
+              portionAmountDecimals: portionAmount?.toExact() ?? '0', // important for exact out, clients are expected to use this for exact out swaps
               quoteGasAndPortionAdjusted: quoteGasAndPortionAdjusted, // not important, clients disregard this
               quoteGasAndPortionAdjustedDecimals: quoteGasAndPortionAdjustedDecimals, // not important, clients disregard this
             }

--- a/test/integ/quote-classic.test.ts
+++ b/test/integ/quote-classic.test.ts
@@ -1894,7 +1894,7 @@ describe('quote', function () {
 
                     expect(quoteJSON.portionBips).to.equal(0);
                     expect(quoteJSON.portionAmount).to.equal('0');
-                    expect(quoteJSON.portionAmountDecimals).to.equal(0);
+                    expect(quoteJSON.portionAmountDecimals).to.equal('0');
                   }
 
                   const {
@@ -1929,14 +1929,8 @@ describe('quote', function () {
                     }
 
                     if (sendPortionEnabled) {
-                      expect(quoteJSON.portionAmount).not.to.be.undefined;
-
-                      const expectedPortionAmount = CurrencyAmount.fromRawAmount(tokenOut, quoteJSON.portionAmount!);
-                      checkPortionRecipientToken(
-                        tokenOutPortionRecipientBefore!,
-                        tokenOutPortionRecipientAfter!,
-                        expectedPortionAmount
-                      );
+                      expect(tokenOutPortionRecipientAfter).to.be.undefined;
+                      expect(tokenOutPortionRecipientBefore).to.be.undefined;
                     }
                   } else {
                     // if the token out is native token, the difference will be slightly larger due to gas. We have no way to know precise gas costs in terms of GWEI * gas units.
@@ -1954,14 +1948,8 @@ describe('quote', function () {
                     }
 
                     if (sendPortionEnabled) {
-                      expect(quoteJSON.portionAmount).not.to.be.undefined;
-
-                      const expectedPortionAmount = CurrencyAmount.fromRawAmount(tokenOut, quoteJSON.portionAmount!);
-                      checkPortionRecipientToken(
-                        tokenOutPortionRecipientBefore!,
-                        tokenOutPortionRecipientAfter!,
-                        expectedPortionAmount
-                      );
+                      expect(tokenOutPortionRecipientAfter).to.be.undefined;
+                      expect(tokenOutPortionRecipientBefore).to.be.undefined;
                     }
                   }
                 });


### PR DESCRIPTION
When generating the portionAmountDecimals response, if portionAmount is 0 we should default to returning 0 instead of undefined.
