### PR TITLE
fix: remove dutch limit requests if ineligible

### DIFF
--- a/lib/fetchers/TokenFetcher.ts
+++ b/lib/fetchers/TokenFetcher.ts
@@ -38,7 +38,7 @@ export class TokenFetcher {
    * Gets the token address for the provided token symbol or address from the DEFAULT_TOKEN_LIST.
    * Throws an error if the token is not found.
    */
-  public resolveTokenSymbolOrAddress = async (chainId: ChainId, symbolOrAddress: string): Promise<string> => {
+  public resolveTokenBySymbolOrAddress = async (chainId: ChainId, symbolOrAddress: string): Promise<string> => {
     // check for native symbols first
     if (NATIVE_NAMES_BY_ID[chainId]!.includes(symbolOrAddress) || symbolOrAddress == NATIVE_ADDRESS) {
       return NATIVE_ADDRESS;

--- a/lib/fetchers/TokenFetcher.ts
+++ b/lib/fetchers/TokenFetcher.ts
@@ -38,7 +38,7 @@ export class TokenFetcher {
    * Gets the token address for the provided token symbol or address from the DEFAULT_TOKEN_LIST.
    * Throws an error if the token is not found.
    */
-  public resolveTokenAddress = async (chainId: ChainId, symbolOrAddress: string): Promise<string> => {
+  public resolveTokenSymbolOrAddress = async (chainId: ChainId, symbolOrAddress: string): Promise<string> => {
     // check for native symbols first
     if (NATIVE_NAMES_BY_ID[chainId]!.includes(symbolOrAddress) || symbolOrAddress == NATIVE_ADDRESS) {
       return NATIVE_ADDRESS;
@@ -58,22 +58,12 @@ export class TokenFetcher {
     }
   };
 
-  public resolveToken = async (chainId: ChainId, address: string): Promise<Currency> => {
+  public getTokenByAddress = async (chainId: ChainId, address: string): Promise<Currency | undefined> => {
     if (address == NATIVE_ADDRESS || address.toLowerCase() == 'eth') {
       return Ether.onChain(chainId);
     }
 
     const tokenListProvider = this.getTokenListProvider(chainId);
-    const token = await tokenListProvider.getTokenByAddress(address);
-    if (token === undefined) {
-      throw new ValidationError(`Could not find token with address ${address}`);
-    }
-    return token;
-  };
-
-  public resolveTokenBySymbolOrAddress = async (chainId: ChainId, symbolOrAddress: string): Promise<Currency> => {
-    // both calls are in-memory, no perf hit
-    const resolvedAddress = await this.resolveTokenAddress(chainId, symbolOrAddress);
-    return await this.resolveToken(chainId, resolvedAddress);
+    return await tokenListProvider.getTokenByAddress(address);
   };
 }

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -171,14 +171,17 @@ export class QuoteHandler extends APIGLambdaHandler<
   private async isDutchEligible(requestBody: QuoteRequestBodyJSON, tokenFetcher: TokenFetcher): Promise<boolean> {
     const [tokenIn, tokenOut] = await Promise.all([
       tokenFetcher.getTokenByAddress(requestBody.tokenInChainId, requestBody.tokenIn),
-      tokenFetcher.getTokenByAddress(requestBody.tokenOutChainId, requestBody.tokenIn),
+      tokenFetcher.getTokenByAddress(requestBody.tokenOutChainId, requestBody.tokenOut),
     ]);
 
     const tokenInNotValid = !tokenIn && requestBody.tokenIn !== NATIVE_ADDRESS;
     const tokenOutNotValid = !tokenOut && requestBody.tokenOut !== NATIVE_ADDRESS;
     if (tokenInNotValid || tokenOutNotValid) {
       log.info(
-        { ...(tokenInNotValid && { tokenIn }), ...(tokenOutNotValid && { tokenOut }) },
+        {
+          ...(tokenInNotValid && { tokenIn: requestBody.tokenIn }),
+          ...(tokenOutNotValid && { tokenOut: requestBody.tokenOut }),
+        },
         'Token/tokens not on token list, filtering out all Dutch Limit requests...'
       );
       return false;

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -72,8 +72,8 @@ export class QuoteHandler extends APIGLambdaHandler<
     };
 
     const beforeResolveTokens = Date.now();
-    const tokenInAddress = await tokenFetcher.resolveTokenSymbolOrAddress(request.tokenInChainId, request.tokenIn);
-    const tokenOutAddress = await tokenFetcher.resolveTokenSymbolOrAddress(request.tokenOutChainId, request.tokenOut);
+    const tokenInAddress = await tokenFetcher.resolveTokenBySymbolOrAddress(request.tokenInChainId, request.tokenIn);
+    const tokenOutAddress = await tokenFetcher.resolveTokenBySymbolOrAddress(request.tokenOutChainId, request.tokenOut);
     metrics.putMetric(
       `Latency-ResolveTokens-ChainId${requestBody.tokenInChainId}`,
       Date.now() - beforeResolveTokens,

--- a/test/unit/entities/DutchQuote.test.ts
+++ b/test/unit/entities/DutchQuote.test.ts
@@ -392,7 +392,6 @@ describe('DutchQuote', () => {
       // portion is 12 bps
       const amountOut = AMOUNT;
       const dutchQuote = createDutchQuote({ amountOut }, 'EXACT_OUTPUT', '1', FLAT_PORTION, true);
-      console.log(dutchQuote.toJSON());
       // since we add the amount to RFQ request
       const amountOutWithPortion = dutchQuote.amountOutStart.add(dutchQuote.portionAmountOutStart);
       // RFQ returns same as mock dutch quote
@@ -411,7 +410,6 @@ describe('DutchQuote', () => {
 
       const quote = DutchQuote.fromResponseBody(dutchQuote.request, DL_QUOTE_JSON_RFQ, '1', FLAT_PORTION);
 
-      console.log(quote.toJSON().orderInfo.outputs);
       // expect the sum of outputs to be amountOutWithPortion,
       // but the first output to the swapper tob e amountOut, and the second output to be the portion to the recipient
       expect(quote.toJSON().orderInfo.outputs[0].startAmount).toEqual(amountOut);

--- a/test/unit/lib/fetchers/TokenFetcher.test.ts
+++ b/test/unit/lib/fetchers/TokenFetcher.test.ts
@@ -70,7 +70,7 @@ describe('TokenFetcher Unit Tests', () => {
       const { input, output } = t;
 
       try {
-        const result = await new TokenFetcher().resolveTokenAddress(input.chainId, input.address);
+        const result = await new TokenFetcher().resolveTokenSymbolOrAddress(input.chainId, input.address);
         expect(_.isEqual(result, output)).toBe(true);
       } catch (e: any) {
         expect(e).toBeInstanceOf(t.errorType);

--- a/test/unit/lib/fetchers/TokenFetcher.test.ts
+++ b/test/unit/lib/fetchers/TokenFetcher.test.ts
@@ -70,7 +70,7 @@ describe('TokenFetcher Unit Tests', () => {
       const { input, output } = t;
 
       try {
-        const result = await new TokenFetcher().resolveTokenSymbolOrAddress(input.chainId, input.address);
+        const result = await new TokenFetcher().resolveTokenBySymbolOrAddress(input.chainId, input.address);
         expect(_.isEqual(result, output)).toBe(true);
       } catch (e: any) {
         expect(e).toBeInstanceOf(t.errorType);

--- a/test/unit/lib/handlers/quote/handler.test.ts
+++ b/test/unit/lib/handlers/quote/handler.test.ts
@@ -161,17 +161,17 @@ describe('QuoteHandler', () => {
     };
     const TokenFetcherMock = (addresses: string[], isError = false): TokenFetcher => {
       const fetcher = {
-        resolveTokenSymbolOrAddress: jest.fn(),
+        resolveTokenBySymbolOrAddress: jest.fn(),
         getTokenByAddress: (_chainId: number, address: string) => [TOKEN_IN, TOKEN_OUT].includes(address),
       };
 
       if (isError) {
-        fetcher.resolveTokenSymbolOrAddress.mockRejectedValue(new Error('error'));
+        fetcher.resolveTokenBySymbolOrAddress.mockRejectedValue(new Error('error'));
         return fetcher as unknown as TokenFetcher;
       }
 
       for (const address of addresses) {
-        fetcher.resolveTokenSymbolOrAddress.mockResolvedValueOnce(address);
+        fetcher.resolveTokenBySymbolOrAddress.mockResolvedValueOnce(address);
       }
       return fetcher as unknown as TokenFetcher;
     };

--- a/test/unit/lib/handlers/quote/handler.test.ts
+++ b/test/unit/lib/handlers/quote/handler.test.ts
@@ -40,9 +40,9 @@ import { ClassicQuote, ClassicQuoteDataJSON, DutchQuote, Quote } from '../../../
 import { QuoteRequestBodyJSON } from '../../../../../lib/entities/request/index';
 import { Permit2Fetcher } from '../../../../../lib/fetchers/Permit2Fetcher';
 import {
-  GET_NO_PORTION_RESPONSE,
   GetPortionResponse,
-  PortionFetcher
+  GET_NO_PORTION_RESPONSE,
+  PortionFetcher,
 } from '../../../../../lib/fetchers/PortionFetcher';
 import { TokenFetcher } from '../../../../../lib/fetchers/TokenFetcher';
 import { ApiInjector, ApiRInj } from '../../../../../lib/handlers/base';
@@ -58,7 +58,7 @@ import { Quoter, SyntheticStatusProvider } from '../../../../../lib/providers';
 import { Erc20__factory } from '../../../../../lib/types/ext/factories/Erc20__factory';
 import { ErrorCode } from '../../../../../lib/util/errors';
 import { setGlobalLogger } from '../../../../../lib/util/log';
-import { PERMIT2_USED, PERMIT_DETAILS, SWAPPER, TOKEN_IN, TOKEN_OUT } from '../../../../constants';
+import { INELIGIBLE_TOKEN, PERMIT2_USED, PERMIT_DETAILS, SWAPPER, TOKEN_IN, TOKEN_OUT } from '../../../../constants';
 
 describe('QuoteHandler', () => {
   const OLD_ENV = process.env;
@@ -161,16 +161,17 @@ describe('QuoteHandler', () => {
     };
     const TokenFetcherMock = (addresses: string[], isError = false): TokenFetcher => {
       const fetcher = {
-        resolveTokenAddress: jest.fn(),
+        resolveTokenSymbolOrAddress: jest.fn(),
+        getTokenByAddress: (_chainId: number, address: string) => [TOKEN_IN, TOKEN_OUT].includes(address),
       };
 
       if (isError) {
-        fetcher.resolveTokenAddress.mockRejectedValue(new Error('error'));
+        fetcher.resolveTokenSymbolOrAddress.mockRejectedValue(new Error('error'));
         return fetcher as unknown as TokenFetcher;
       }
 
       for (const address of addresses) {
-        fetcher.resolveTokenAddress.mockResolvedValueOnce(address);
+        fetcher.resolveTokenSymbolOrAddress.mockResolvedValueOnce(address);
       }
       return fetcher as unknown as TokenFetcher;
     };
@@ -705,6 +706,44 @@ describe('QuoteHandler', () => {
 
           const bodyJSON = JSON.parse(res.body);
           expect(bodyJSON.routing).toEqual(RoutingType.DUTCH_LIMIT);
+        });
+      });
+
+      describe('removes ineligible dutch requests', () => {
+        it('removes dutch request if token in is not eligible', async () => {
+          const quoters = { [RoutingType.DUTCH_LIMIT]: RfqQuoterMock(DL_QUOTE_EXACT_IN_BETTER) };
+          const tokenFetcher = TokenFetcherMock([INELIGIBLE_TOKEN, TOKEN_OUT]);
+          const portionFetcher = PortionFetcherMock(GET_NO_PORTION_RESPONSE);
+          const permit2Fetcher = Permit2FetcherMock(PERMIT_DETAILS);
+          const syntheticStatusProvider = SyntheticStatusProviderMock(false);
+
+          const res = await getQuoteHandler(
+            quoters,
+            tokenFetcher,
+            portionFetcher,
+            permit2Fetcher,
+            syntheticStatusProvider
+          ).handler(getEvent(DL_REQUEST_BODY), {} as unknown as Context);
+          const quoteJSON = JSON.parse(res.body);
+          expect(quoteJSON.errorCode).toEqual(ErrorCode.QuoteError);
+        });
+
+        it('removes dutch request if token out is not eligible', async () => {
+          const quoters = { [RoutingType.DUTCH_LIMIT]: RfqQuoterMock(DL_QUOTE_EXACT_IN_BETTER) };
+          const tokenFetcher = TokenFetcherMock([TOKEN_IN, INELIGIBLE_TOKEN]);
+          const portionFetcher = PortionFetcherMock(GET_NO_PORTION_RESPONSE);
+          const permit2Fetcher = Permit2FetcherMock(PERMIT_DETAILS);
+          const syntheticStatusProvider = SyntheticStatusProviderMock(false);
+
+          const res = await getQuoteHandler(
+            quoters,
+            tokenFetcher,
+            portionFetcher,
+            permit2Fetcher,
+            syntheticStatusProvider
+          ).handler(getEvent(DL_REQUEST_BODY), {} as unknown as Context);
+          const quoteJSON = JSON.parse(res.body);
+          expect(quoteJSON.errorCode).toEqual(ErrorCode.QuoteError);
         });
       });
     });

--- a/test/unit/lib/handlers/quote/handler.test.ts
+++ b/test/unit/lib/handlers/quote/handler.test.ts
@@ -712,7 +712,7 @@ describe('QuoteHandler', () => {
       describe('removes ineligible dutch requests', () => {
         it('removes dutch request if token in is not eligible', async () => {
           const quoters = { [RoutingType.DUTCH_LIMIT]: RfqQuoterMock(DL_QUOTE_EXACT_IN_BETTER) };
-          const tokenFetcher = TokenFetcherMock([INELIGIBLE_TOKEN, TOKEN_OUT]);
+          const tokenFetcher = TokenFetcherMock([TOKEN_IN, TOKEN_OUT]);
           const portionFetcher = PortionFetcherMock(GET_NO_PORTION_RESPONSE);
           const permit2Fetcher = Permit2FetcherMock(PERMIT_DETAILS);
           const syntheticStatusProvider = SyntheticStatusProviderMock(false);
@@ -723,14 +723,14 @@ describe('QuoteHandler', () => {
             portionFetcher,
             permit2Fetcher,
             syntheticStatusProvider
-          ).handler(getEvent(DL_REQUEST_BODY), {} as unknown as Context);
+          ).handler(getEvent({ ...DL_REQUEST_BODY, tokenIn: INELIGIBLE_TOKEN }), {} as unknown as Context);
           const quoteJSON = JSON.parse(res.body);
           expect(quoteJSON.errorCode).toEqual(ErrorCode.QuoteError);
         });
 
         it('removes dutch request if token out is not eligible', async () => {
           const quoters = { [RoutingType.DUTCH_LIMIT]: RfqQuoterMock(DL_QUOTE_EXACT_IN_BETTER) };
-          const tokenFetcher = TokenFetcherMock([TOKEN_IN, INELIGIBLE_TOKEN]);
+          const tokenFetcher = TokenFetcherMock([TOKEN_IN, TOKEN_OUT]);
           const portionFetcher = PortionFetcherMock(GET_NO_PORTION_RESPONSE);
           const permit2Fetcher = Permit2FetcherMock(PERMIT_DETAILS);
           const syntheticStatusProvider = SyntheticStatusProviderMock(false);
@@ -741,7 +741,7 @@ describe('QuoteHandler', () => {
             portionFetcher,
             permit2Fetcher,
             syntheticStatusProvider
-          ).handler(getEvent(DL_REQUEST_BODY), {} as unknown as Context);
+          ).handler(getEvent({ ...DL_REQUEST_BODY, tokenOut: INELIGIBLE_TOKEN }), {} as unknown as Context);
           const quoteJSON = JSON.parse(res.body);
           expect(quoteJSON.errorCode).toEqual(ErrorCode.QuoteError);
         });


### PR DESCRIPTION
## Summary
We aren't filtering out dutch limit requests (RFQ quote requests) that have ineligible token addresses. We send the requests to the param service and then filter out the response if the token address for either token does not fall in the `DEFAULT_TOKEN_LIST`.

## Changes
- Add a function `getTokenByAddress` to the `tokenFetcher` that will allow us to determine if token is in the default token list
- Add a function `isDutchEligible` to check all the pre-quote eligibility checks then remove dutch requests if necessary.
- Remove some leftover console.logs from fee team work

## Tests
- Testing locally
- Unit tests