### PR TITLE
fix: token filtering for UniswapX

### DIFF
--- a/lib/fetchers/TokenFetcher.ts
+++ b/lib/fetchers/TokenFetcher.ts
@@ -58,12 +58,22 @@ export class TokenFetcher {
     }
   };
 
-  public getTokenByAddress = async (chainId: ChainId, address: string): Promise<Currency | undefined> => {
-    if (address == NATIVE_ADDRESS || address.toLowerCase() == 'eth') {
+  /**
+   * Gets the token currency object for the provided token symbol or address if found in the DEFAULT_TOKEN_LIST.
+   * Returns undefined if the token is not found.
+   */
+  public getTokenBySymbolOrAddress = async (
+    chainId: ChainId,
+    symbolOrAddress: string
+  ): Promise<Currency | undefined> => {
+    // check for native symbols first
+    if (NATIVE_NAMES_BY_ID[chainId]!.includes(symbolOrAddress) || symbolOrAddress == NATIVE_ADDRESS) {
       return Ether.onChain(chainId);
     }
 
     const tokenListProvider = this.getTokenListProvider(chainId);
-    return await tokenListProvider.getTokenByAddress(address);
+    const tokenAddress = await this.resolveTokenBySymbolOrAddress(chainId, symbolOrAddress);
+
+    return await tokenListProvider.getTokenByAddress(tokenAddress);
   };
 }

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -170,8 +170,8 @@ export class QuoteHandler extends APIGLambdaHandler<
 
   private async isDutchEligible(requestBody: QuoteRequestBodyJSON, tokenFetcher: TokenFetcher): Promise<boolean> {
     const [tokenIn, tokenOut] = await Promise.all([
-      tokenFetcher.getTokenByAddress(requestBody.tokenInChainId, requestBody.tokenIn),
-      tokenFetcher.getTokenByAddress(requestBody.tokenOutChainId, requestBody.tokenOut),
+      tokenFetcher.getTokenBySymbolOrAddress(requestBody.tokenInChainId, requestBody.tokenIn),
+      tokenFetcher.getTokenBySymbolOrAddress(requestBody.tokenOutChainId, requestBody.tokenOut),
     ]);
 
     const tokenInNotValid = !tokenIn && requestBody.tokenIn !== NATIVE_ADDRESS;
@@ -235,7 +235,7 @@ export class QuoteHandler extends APIGLambdaHandler<
   private async getTokenSymbolOrAbbr(tokenFetcher: TokenFetcher, chainId: number, address: string): Promise<string> {
     let symbol = address.slice(0, 6);
     try {
-      symbol = (await tokenFetcher.getTokenByAddress(chainId, symbol))?.symbol ?? symbol;
+      symbol = (await tokenFetcher.getTokenBySymbolOrAddress(chainId, symbol))?.symbol ?? symbol;
     } catch {
       /* empty */
     }

--- a/test/unit/lib/handlers/quote/handler.test.ts
+++ b/test/unit/lib/handlers/quote/handler.test.ts
@@ -162,7 +162,7 @@ describe('QuoteHandler', () => {
     const TokenFetcherMock = (addresses: string[], isError = false): TokenFetcher => {
       const fetcher = {
         resolveTokenBySymbolOrAddress: jest.fn(),
-        getTokenByAddress: (_chainId: number, address: string) => [TOKEN_IN, TOKEN_OUT].includes(address),
+        getTokenBySymbolOrAddress: (_chainId: number, address: string) => [TOKEN_IN, TOKEN_OUT].includes(address),
       };
 
       if (isError) {


### PR DESCRIPTION
## Summary
In my previous change #314, we weren't checking for the token symbol only the address. If a request was UniswapX but had token symbols for tokenIn/tokenOut the filter would remove the DUTCH_LIMIT requests.

## Changes
- Change `getTokenByAddress` -> `getTokenByAddressOrSymbol`. First try fetching the token using symbol then if that fails use the address.

## Testing
Curled locally
Unit tests fix
Ran integ test locally