### PR TITLE
fix: Switch over to ethers StaticJsonProvider

### DIFF
--- a/lib/entities/context/DutchQuoteContext.ts
+++ b/lib/entities/context/DutchQuoteContext.ts
@@ -34,7 +34,7 @@ const BPS = 10000;
 const RFQ_QUOTE_UPPER_BOUND_MULTIPLIER = 3;
 
 export type DutchQuoteContextProviders = {
-  rpcProvider: ethers.providers.JsonRpcProvider;
+  rpcProvider: ethers.providers.StaticJsonRpcProvider;
   syntheticStatusProvider: SyntheticStatusProvider;
 };
 
@@ -42,7 +42,7 @@ export type DutchQuoteContextProviders = {
 export class DutchQuoteContext implements QuoteContext {
   routingType: RoutingType.DUTCH_LIMIT;
   private log: Logger;
-  private rpcProvider: ethers.providers.JsonRpcProvider;
+  private rpcProvider: ethers.providers.StaticJsonRpcProvider;
   private syntheticStatusProvider: SyntheticStatusProvider;
 
   public requestKey: string;

--- a/lib/entities/context/index.ts
+++ b/lib/entities/context/index.ts
@@ -85,7 +85,7 @@ export class QuoteContextManager {
 
 export type QuoteContextProviders = {
   permit2Fetcher: Permit2Fetcher;
-  rpcProvider: ethers.providers.JsonRpcProvider;
+  rpcProvider: ethers.providers.StaticJsonRpcProvider;
   syntheticStatusProvider: SyntheticStatusProvider;
 };
 

--- a/lib/fetchers/Permit2Fetcher.ts
+++ b/lib/fetchers/Permit2Fetcher.ts
@@ -28,7 +28,7 @@ export class Permit2Fetcher {
     metrics.putMetric(`Permit2FetcherRequest`, 1);
     try {
       const rpcUrl = this.rpcUrlMap.get(chainId);
-      const rpcProvider = new ethers.providers.JsonRpcProvider(rpcUrl);
+      const rpcProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
       allowance = await this.permit2.connect(rpcProvider).allowance(ownerAddress, tokenAddress, spenderAddress);
       metrics.putMetric(`Permit2FetcherSuccess`, 1);
     } catch (e) {

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -64,7 +64,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       throw new ValidationError(`Cannot request quotes for tokens on different chains`);
     }
 
-    const provider = new ethers.providers.JsonRpcProvider(rpcUrlMap.get(requestBody.tokenInChainId));
+    const provider = new ethers.providers.StaticJsonRpcProvider(rpcUrlMap.get(requestBody.tokenInChainId));
 
     const request = {
       ...requestBody,


### PR DESCRIPTION
From https://github.com/Uniswap/routing-api/pull/404

> From this issue in ethers: https://github.com/ethers-io/ethers.js/issues/901
> We can switch to using the StaticJsonRpcProvider which avoids an unnecessary chainId call to infura, saving about 30% of requests to infura

The only issue is if we share a provider across different cross chain calls but we don't do that anywhere afaik. Also that wouldn't work since we don't have a multi chain rpc.