### PR TITLE
chore: remove route back to ETH calls

### DIFF
--- a/lib/entities/context/DutchQuoteContext.ts
+++ b/lib/entities/context/DutchQuoteContext.ts
@@ -3,12 +3,7 @@ import { PERMIT2_ADDRESS } from '@uniswap/permit2-sdk';
 import { Protocol } from '@uniswap/router-sdk';
 import { ChainId, TradeType } from '@uniswap/sdk-core';
 
-import {
-  CachingTokenListProvider,
-  ID_TO_CHAIN_ID,
-  NodeJSCache,
-  WRAPPED_NATIVE_CURRENCY,
-} from '@uniswap/smart-order-router';
+import { CachingTokenListProvider, NodeJSCache, WRAPPED_NATIVE_CURRENCY } from '@uniswap/smart-order-router';
 import Logger from 'bunyan';
 import { BigNumber, ethers } from 'ethers';
 import NodeCache from 'node-cache';
@@ -71,43 +66,16 @@ export class DutchQuoteContext implements QuoteContext {
     this.classicKey = classicRequest.key();
     this.log.info({ classicRequest: classicRequest.info }, 'Adding synthetic classic request');
 
-    const result = [this.request, classicRequest];
-
-    const wrappedNativeAddress = WRAPPED_NATIVE_CURRENCY[ID_TO_CHAIN_ID(this.request.info.tokenOutChainId)].address;
-    if (this.request.info.tokenOut !== wrappedNativeAddress && this.request.info.tokenOut !== NATIVE_ADDRESS) {
-      this.needsRouteToNative = true;
-      const routeBackToNativeRequest = new ClassicRequest(
-        {
-          ...this.request.info,
-          type: TradeType.EXACT_OUTPUT,
-          tokenIn: this.request.info.tokenOut,
-          amount: ethers.utils.parseEther('1'),
-          tokenOut: wrappedNativeAddress,
-        },
-        {
-          protocols: [Protocol.MIXED, Protocol.V2, Protocol.V3],
-        }
-      );
-      this.routeToNativeKey = routeBackToNativeRequest.key();
-      result.push(routeBackToNativeRequest);
-
-      this.log.info(
-        { routeBackToNativeRequest: routeBackToNativeRequest.info },
-        'Adding synthetic back to native classic request'
-      );
-    }
-
-    return result;
+    return [this.request, classicRequest];
   }
 
   async resolveHandler(dependencies: QuoteByKey): Promise<Quote | null> {
     const classicQuote = dependencies[this.classicKey] as ClassicQuote;
-    const routeBackToNative = dependencies[this.routeToNativeKey] as ClassicQuote;
     const rfqQuote = dependencies[this.requestKey] as DutchQuote;
 
     const [quote, syntheticQuote] = await Promise.all([
       this.getRfqQuote(rfqQuote, classicQuote),
-      this.getSyntheticQuote(classicQuote, routeBackToNative),
+      this.getSyntheticQuote(classicQuote),
     ]);
 
     // handle cases where we only either have RFQ or synthetic


### PR DESCRIPTION
## Summary
As part of our ongoing effort to reduce routing API / AWS costs we decided the lowest hanging fruit would be this extra routing api call. For every UniswapX call we are 2x calling routing api. This call checks if the output token for the UniswapX swap has a route back to ETH. The only reason we have this call is to ensure the broadcaster doesn't get stuck with an illiquid profit token. 

We want to do some costs cutting before rolling out X to 100% so part 1 of this initiative is to remove the call in URA and then part 2 would be to update the broadcaster to throw out illiquid swaps. This can be prioritized later as for right now it is most likely safe to assume back stopped order have a route back to ETH. Also, the broadcaster fills very small amount of orders.

## Changes
Remove the route back to ETH call

## Testing
unit test pass
deployed changes locally and confirmed the extra call is not made
integ tests run locally
