### PR TITLE
feat: override auctionPeriod to 120s for large (>= $10,000) trades on mainnet

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -5,6 +5,7 @@ export const DEFAULT_SLIPPAGE_TOLERANCE = '0.5'; // 0.5%
 export const DEFAULT_ROUTING_API_DEADLINE = 600; // 10 minutes
 export const BPS = 10000; // 100.00%
 export const NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const LARGE_TRADE_USD_THRESHOLD = 10_000;
 
 // Because we don't natively support ETH input and require users to wrap their ETH before swapping,
 // the user experience is significantly worse (requiring 3 user interactions).

--- a/lib/entities/context/DutchQuoteContext.ts
+++ b/lib/entities/context/DutchQuoteContext.ts
@@ -13,7 +13,7 @@ import Logger from 'bunyan';
 import { BigNumber, ethers } from 'ethers';
 import NodeCache from 'node-cache';
 import { QuoteByKey, QuoteContext } from '.';
-import { DEFAULT_ROUTING_API_DEADLINE, NATIVE_ADDRESS, RoutingType } from '../../constants';
+import { DEFAULT_ROUTING_API_DEADLINE, LARGE_TRADE_USD_THRESHOLD, NATIVE_ADDRESS, RoutingType } from '../../constants';
 import {
   ClassicQuote,
   ClassicQuoteDataJSON,
@@ -261,8 +261,8 @@ export class DutchQuoteContext implements QuoteContext {
       return false;
     }
     const quoteSizeEstimateUSD = getQuoteSizeEstimateUSD(classicQuote);
-    log.info({ quoteSizeEstimateUSD }, 'Quote size estimate in USD');
-    return quoteSizeEstimateUSD >= 10000;
+    log.info({ quoteSize: quoteSizeEstimateUSD.toString() }, 'Quote size estimate in USD');
+    return quoteSizeEstimateUSD.gte(LARGE_TRADE_USD_THRESHOLD);
   }
 
   rfqQuoteTooGood(quote: DutchQuote, classicQuote: ClassicQuote): boolean {

--- a/lib/entities/quote/DutchQuote.ts
+++ b/lib/entities/quote/DutchQuote.ts
@@ -10,7 +10,6 @@ import {
   BPS,
   DEFAULT_START_TIME_BUFFER_SECS,
   frontendAndUraEnablePortion,
-  LARGE_TRADE_USD_THRESHOLD,
   NATIVE_ADDRESS,
   OPEN_QUOTE_START_TIME_BUFFER_SECS,
   RoutingType,
@@ -25,7 +24,6 @@ import { generateRandomNonce } from '../../util/nonce';
 import { currentTimestampInMs, timestampInMstoSeconds } from '../../util/time';
 import { ClassicQuote } from './ClassicQuote';
 import { LogJSON } from './index';
-import { getQuoteSizeEstimateUSD } from '../../util/quoteMath';
 
 export type DutchQuoteDerived = {
   largeTrade: boolean;
@@ -208,7 +206,7 @@ export class DutchQuote implements IQuote {
       classic.getPortionBips(),
       classic.getPortionRecipient(),
       {
-        largeTrade: getQuoteSizeEstimateUSD(classic) >= LARGE_TRADE_USD_THRESHOLD,
+        largeTrade: options?.largeTrade ?? false,
       }
     );
   }

--- a/lib/util/quoteMath.ts
+++ b/lib/util/quoteMath.ts
@@ -1,11 +1,12 @@
 import { BigNumber } from "ethers";
+import { BigNumber as BN } from "bignumber.js";
 import { ClassicQuoteDataJSON, Quote } from "../entities";
 
 // quoteSizeUSD = (multiple of gas-cost-equivalent quote token) * (gas cost in USD)
 export function getQuoteSizeEstimateUSD(classicQuote: Quote) {
     const classicQuoteData = classicQuote.toJSON() as ClassicQuoteDataJSON;
-  return parseFloat(
+  return new BN(
     BigNumber.from(classicQuoteData.quoteGasAdjusted)
       .div(BigNumber.from(classicQuoteData.gasUseEstimateQuote)).toString())
-      * parseFloat(classicQuoteData.gasUseEstimateUSD);
+    .times(new BN(classicQuoteData.gasUseEstimateUSD));
 }

--- a/lib/util/quoteMath.ts
+++ b/lib/util/quoteMath.ts
@@ -1,0 +1,11 @@
+import { BigNumber } from "ethers";
+import { ClassicQuoteDataJSON, Quote } from "../entities";
+
+// quoteSizeUSD = (multiple of gas-cost-equivalent quote token) * (gas cost in USD)
+export function getQuoteSizeEstimateUSD(classicQuote: Quote) {
+    const classicQuoteData = classicQuote.toJSON() as ClassicQuoteDataJSON;
+  return parseFloat(
+    BigNumber.from(classicQuoteData.quoteGasAdjusted)
+      .div(BigNumber.from(classicQuoteData.gasUseEstimateQuote)).toString())
+      * parseFloat(classicQuoteData.gasUseEstimateUSD);
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "aws-embedded-metrics": "^4.1.0",
     "axios": "^1.2.1",
     "axios-retry": "^3.4.0",
+    "bignumber.js": "^9.1.2",
     "bunyan": "^1.8.15",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",

--- a/test/unit/entities/DutchQuote.test.ts
+++ b/test/unit/entities/DutchQuote.test.ts
@@ -112,10 +112,10 @@ describe('DutchQuote', () => {
     it.each([
       { title: 'overrides', largeTrade: true, },
       { title: 'does not override', largeTrade: false }
-    ])('$title auctionPeriodSec if order size is considered large: $largeTrade', async (largeTrade) => {
-      const classic = largeTrade ? CLASSIC_QUOTE_EXACT_IN_LARGE : CLASSIC_QUOTE_EXACT_IN_SMALL;
-      const reparamatrized = DutchQuote.reparameterize(DL_QUOTE_EXACT_IN_LARGE, classic);
-      if (largeTrade) {
+    ])('$title auctionPeriodSec if order size is considered large: $largeTrade', async (params) => {
+      const classic = params.largeTrade ? CLASSIC_QUOTE_EXACT_IN_LARGE : CLASSIC_QUOTE_EXACT_IN_SMALL;
+      const reparamatrized = DutchQuote.reparameterize(DL_QUOTE_EXACT_IN_LARGE, classic, {hasApprovedPermit2: true, largeTrade: params.largeTrade});
+      if (params.largeTrade) {
         expect(reparamatrized.auctionPeriodSecs).toEqual(120);
       } else {
         expect(reparamatrized.auctionPeriodSecs).toEqual(60);

--- a/test/unit/lib/entities/context/DutchQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/DutchQuoteContext.test.ts
@@ -15,7 +15,6 @@ import {
   CHAIN_OUT_ID,
   ETH_IN,
   TOKEN_IN,
-  USDC_ADDRESS,
 } from '../../../../constants';
 import {
   BASE_REQUEST_INFO_EXACT_IN,

--- a/test/unit/lib/util/quoteMath.test.ts
+++ b/test/unit/lib/util/quoteMath.test.ts
@@ -1,0 +1,22 @@
+import { createClassicQuote } from '../../../utils/fixtures';
+import { getQuoteSizeEstimateUSD } from '../../../../lib/util/quoteMath';
+
+describe('quoteMath', () => {
+  describe('getQuoteSizeEstimateUSD', () => {
+    it('should derive quote size from gas parameters of classic quote', () => {
+      const quote = createClassicQuote({}, { type: 'EXACT_INPUT' });
+      /*
+       * gasPriceWei: 10000
+       * gasUseEstimate: 100
+       * gasUseEstimateUSD: 100
+       * quote: 1000000000000000000
+       * gasUseEstimateQuote: 100
+       * 
+       * quoteSizeUSD = (multiple of gas-cost-equivalent quote token) * (gas cost in USD)
+       *               = (quote / gasUseEstimateQuote) * gasUseEstimateUSD
+       *               = (1000000000000000000 / 100) * 100
+      */
+      expect(getQuoteSizeEstimateUSD(quote)).toBe(1000000000000000000);
+    })
+  })
+});

--- a/test/unit/lib/util/quoteMath.test.ts
+++ b/test/unit/lib/util/quoteMath.test.ts
@@ -1,5 +1,6 @@
 import { createClassicQuote } from '../../../utils/fixtures';
 import { getQuoteSizeEstimateUSD } from '../../../../lib/util/quoteMath';
+import { BigNumber as BN } from 'bignumber.js';
 
 describe('quoteMath', () => {
   describe('getQuoteSizeEstimateUSD', () => {
@@ -16,7 +17,7 @@ describe('quoteMath', () => {
        *               = (quote / gasUseEstimateQuote) * gasUseEstimateUSD
        *               = (1000000000000000000 / 100) * 100
       */
-      expect(getQuoteSizeEstimateUSD(quote)).toBe(1000000000000000000);
+      expect(getQuoteSizeEstimateUSD(quote)).toStrictEqual(new BN('1000000000000000000'));
     })
   })
 });

--- a/test/utils/fixtures.ts
+++ b/test/utils/fixtures.ts
@@ -62,7 +62,6 @@ export const QUOTE_REQUEST_BODY_MULTI: QuoteRequestBodyJSON = {
       routingType: RoutingType.DUTCH_LIMIT,
       swapper: SWAPPER,
       exclusivityOverrideBps: 12,
-      auctionPeriodSecs: 60,
       deadlineBufferSecs: 12,
     },
     {
@@ -147,7 +146,6 @@ export function makeDutchRequest(
         routingType: RoutingType.DUTCH_LIMIT,
         swapper: SWAPPER,
         exclusivityOverrideBps: 12,
-        auctionPeriodSecs: 60,
         deadlineBufferSecs: 12,
         ...configOverrides,
       },
@@ -450,6 +448,7 @@ export const CLASSIC_QUOTE_EXACT_IN_WORSE_WITH_PORTION = createClassicQuote(
   undefined,
   FLAT_PORTION
 );
+export const CLASSIC_QUOTE_EXACT_IN_SMALL = createClassicQuote({gasUseEstimateQuote: '1', quoteGasAdjusted: '10', gasUseEstimateUSD: '100' }, { type: 'EXACT_INPUT' });
 export const CLASSIC_QUOTE_EXACT_IN_LARGE = createClassicQuote({}, { type: 'EXACT_INPUT' });
 export const CLASSIC_QUOTE_EXACT_IN_LARGE_WITH_PORTION = createClassicQuote(
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,6 +2461,11 @@ bignumber.js@^9.0.2:
   resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz"
   integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
 
+bignumber.js@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"


### PR DESCRIPTION
Use gas-related fields in classic quote to estimate trade size. Doing this for mainnet only because `gasUseEstimateUSD` isn't as reliable from what I've seen on L2s. 
e.g. ARB swap: `gasUseEstimateUSD": "3.641673351807764822"`
