### PR TITLE
fix: pass in chainId to StaticJsonRpcProvider

### DIFF
--- a/lib/fetchers/Permit2Fetcher.ts
+++ b/lib/fetchers/Permit2Fetcher.ts
@@ -28,7 +28,7 @@ export class Permit2Fetcher {
     metrics.putMetric(`Permit2FetcherRequest`, 1);
     try {
       const rpcUrl = this.rpcUrlMap.get(chainId);
-      const rpcProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
+      const rpcProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl, chainId);
       allowance = await this.permit2.connect(rpcProvider).allowance(ownerAddress, tokenAddress, spenderAddress);
       metrics.putMetric(`Permit2FetcherSuccess`, 1);
     } catch (e) {

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -64,7 +64,7 @@ export class QuoteHandler extends APIGLambdaHandler<
       throw new ValidationError(`Cannot request quotes for tokens on different chains`);
     }
 
-    const provider = new ethers.providers.StaticJsonRpcProvider(rpcUrlMap.get(requestBody.tokenInChainId));
+    const provider = new ethers.providers.StaticJsonRpcProvider(rpcUrlMap.get(requestBody.tokenInChainId), requestBody.tokenInChainId); // specify chainId to avoid detecctNetwork() call on initialization
 
     const request = {
       ...requestBody,


### PR DESCRIPTION
if not specified, a `detectNetwork()` call is performed on instantiation 