### PR TITLE
Forward intent param to RoutingAPI

### DIFF
--- a/lib/entities/request/index.ts
+++ b/lib/entities/request/index.ts
@@ -31,6 +31,7 @@ export interface QuoteRequestInfo {
   useUniswapX?: boolean;
   sendPortionEnabled?: boolean;
   portion?: Portion;
+  intent?: string;
 }
 
 export interface QuoteRequestBodyJSON extends Omit<QuoteRequestInfo, 'type' | 'amount'> {
@@ -64,6 +65,7 @@ export function parseQuoteRequests(body: QuoteRequestBodyJSON): {
     swapper: body.swapper,
     sendPortionEnabled: body.sendPortionEnabled,
     portion: body.portion,
+    intent: body.intent,
   };
 
   const requests = body.configs.flatMap((config) => {

--- a/lib/handlers/quote/schema.ts
+++ b/lib/handlers/quote/schema.ts
@@ -21,6 +21,7 @@ export const PostQuoteRequestBodyJoi = Joi.object({
     }),
   swapper: FieldValidator.address.optional(),
   useUniswapX: Joi.boolean().default(false).optional(),
+  intent: Joi.string().optional(),
 });
 
 export const PostQuoteResponseJoi = Joi.object({

--- a/lib/providers/quoters/RoutingApiQuoter.ts
+++ b/lib/providers/quoters/RoutingApiQuoter.ts
@@ -131,6 +131,7 @@ export class RoutingApiQuoter implements Quoter {
             portionBips: request.info.portion.bips,
             portionRecipient: request.info.portion.recipient,
           }),
+        ...(request.info.intent && { intent: request.info.intent }),
       })
     );
   }


### PR DESCRIPTION
RoutingAPI receives an intent param that helps it change its configuration to adapt to different intents.

URA is just in charge of forwarding the param if it exists.
