### PR TITLE
Test-Fix: bullet whale insufficient ETH for gas & UniswapX USDC -> DAI quote

### DIFF
--- a/test/integ/quote-gouda.test.ts
+++ b/test/integ/quote-gouda.test.ts
@@ -791,7 +791,7 @@ describe('quoteUniswapX', function () {
         GREENLIST_STABLE_TO_STABLE_PAIRS.forEach(([tokenIn, tokenOut]) => {
           sendPortionEnabledValues.forEach((sendPortionEnabled) => {
             it(`stable-to-stable ${tokenIn.symbol} -> ${tokenOut.symbol} carveout sendPortionEnabled = ${sendPortionEnabled}`, async () => {
-              const originalAmount = '100';
+              const originalAmount = '1000';
               const tokenInAddress = tokenIn.isNative ? NATIVE_ADDRESS : tokenIn.address;
               const tokenOutAddress = tokenOut.isNative ? NATIVE_ADDRESS : tokenOut.address;
               const amount = await getAmountFromToken(type, tokenIn.wrapped, tokenOut.wrapped, originalAmount);

--- a/test/utils/forkAndFund.ts
+++ b/test/utils/forkAndFund.ts
@@ -73,6 +73,12 @@ export const fund = async (
       const whale = WHALES[i];
       const whaleAccount = ethers.provider.getSigner(whale);
       try {
+        // Send native ETH from hardhat alice test address, so that whale accounts have sufficient ETH to pay for gas
+        await alice.sendTransaction({
+          to: whale,
+          value: ethers.utils.parseEther('0.1'), // Sends exactly 0.1 ether
+        })
+
         const whaleToken: Erc20 = Erc20__factory.connect(currency.wrapped.address, whaleAccount);
 
         await whaleToken.transfer(alice.address, ethers.utils.parseUnits(amount, currency.decimals));
@@ -80,7 +86,9 @@ export const fund = async (
         break;
       } catch (err) {
         if (i == WHALES.length - 1) {
-          throw new Error(`Could not fund ${amount} ${currency.symbol} from any whales.`);
+          throw new Error(
+            `Could not fund ${amount} ${currency.symbol} from any whales. Original error ${JSON.stringify(err)}`
+          )
         }
       }
     }


### PR DESCRIPTION
- [x] Same fix as https://github.com/Uniswap/routing-api/pull/429/files
- [x] fix the UniswapX USDC -> DAI quote. Turned out the trade size was too small, so USDC -> DAI X quote always skips synthetic quote from classic:
![Screenshot 2023-11-21 at 10 44 09 AM](https://github.com/Uniswap/unified-routing-api/assets/91580504/6ead0341-af9f-40a4-b0ac-a9cbd3e8f429)
Fix is to increase the trade size 10x. All the quoteUniswapX integ-test passed on my local https://app.warp.dev/block/bCIz89AkdhiKo8wpKcy5q6
