### PR TITLE
Test-Fix: portion uniswapx quote integ-test to always use synthetic quote for ETH -> USDC

### DIFF
--- a/test/integ/quote-gouda.test.ts
+++ b/test/integ/quote-gouda.test.ts
@@ -652,7 +652,7 @@ describe('quoteUniswapX', function () {
                     // only use non-synthetic quotes if it's ETH -> USDC
                     // otherwise use synthetic quotes
                     // fillers should be able to quote ETH -> USDC since this is the most popular pair
-                    useSyntheticQuotes: !(tokenIn.isNative && tokenOut.symbol === 'USDC'),
+                    useSyntheticQuotes: true,
                   },
                 ] as RoutingConfigJSON[],
               };


### PR DESCRIPTION
RFQ quoter stopped returning quote for ETH -> USDC, and it blocks URA pipeline:
<img width="1443" alt="Screenshot 2023-11-21 at 11 14 15 AM" src="https://github.com/Uniswap/unified-routing-api/assets/91580504/aac35777-93ac-4f2a-adf7-6d01cea1600c">

In order to unblock URA pipeline, we should fix the uniswapx portion integ-test to always use synthetic quote. It appears we cannot rely on RFQ quoter even for the most popular swap ETH -> USDC, even if the trade size is non-trivial (10 ETH).

quoteUniswapX integ-test after the test setup fix https://app.warp.dev/block/F7HTITuswHrunXlsyqUVJv