### PR TITLE
Add x-request-source to Access-Control-Allow-Headers in API response header

### DIFF
--- a/lib/handlers/base/api-handler.ts
+++ b/lib/handlers/base/api-handler.ts
@@ -95,7 +95,7 @@ export abstract class APIGLambdaHandler<
         headers: {
           ...response.headers,
           'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
+          'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,x-request-source',
           'Access-Control-Allow-Credentials': true,
           'Content-Type': 'application/json',
         },


### PR DESCRIPTION
This is to prevent CORS error `Request header field x-request-source is not allowed by Access-Control-Allow-Headers in preflight response`.