### PR TITLE
chore: removed uneccessary logs

### DIFF
--- a/lib/handlers/base/api-handler.ts
+++ b/lib/handlers/base/api-handler.ts
@@ -113,8 +113,6 @@ export abstract class APIGLambdaHandler<
           requestId: context.awsRequestId,
         });
 
-        log.info({ event, context }, 'Request started.');
-
         let requestBody: ReqBody;
         let requestQueryParams: ReqQueryParams;
         try {


### PR DESCRIPTION
## Summary
Removed two unnecessary logs. We log the entire request context and API Gateway event at the beginning of the request. This is one of our largest logs and the least useful. We also log the raw body of the request after we return a response. This is a duplicate log.