### PR TITLE
feat: new RPCs secret with QuickNode for BNB RPC

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -111,7 +111,7 @@ export class APIPipeline extends Stack {
 
     const jsonRpcProvidersSecret = sm.Secret.fromSecretAttributes(this, 'RPCProviderUrls', {
       // Infura RPC urls
-      secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:gouda-service-rpc-urls-3-SFaiCq',
+      secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:prod/URA/rpc-urls/v1-sRkBDE',
     });
 
     const jsonRpcProviders = {} as { [chainKey: string]: string };


### PR DESCRIPTION
# Description

- This PR aims to point URA to a new secret which includes a working version of a BNB RPC from QuickNode
- It also moves URA away from using X's RPCs
- The appropriate permissions have been given to the secret
- The secret has been been encrypted using CMK