### PR TITLE
feat: Adjust concurrencies for URA

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -140,7 +140,7 @@ export class APIPipeline extends Stack {
     // Beta us-east-2
     const betaUsEast2Stage = new APIStage(this, 'beta-us-east-2', {
       env: { account: '665191769009', region: 'us-east-2' },
-      provisionedConcurrency: 50,
+      provisionedConcurrency: 1,
       stage: STAGE.BETA,
       internalApiKey: internalKeySecret.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
@@ -168,7 +168,7 @@ export class APIPipeline extends Stack {
     // Prod us-east-2
     const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
       env: { account: '652077092967', region: 'us-east-2' },
-      provisionedConcurrency: 200,
+      provisionedConcurrency: 50,
       internalApiKey: internalKeySecret.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       stage: STAGE.PROD,

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -235,7 +235,7 @@ export class APIStack extends cdk.Stack {
       quoteTarget.node.addDependency(quoteLambdaAlias);
 
       quoteTarget.scaleToTrackMetric('QuoteProvConcTracking', {
-        targetValue: 0.8,
+        targetValue: 0.7,
         predefinedMetric: aws_asg.PredefinedMetric.LAMBDA_PROVISIONED_CONCURRENCY_UTILIZATION,
       });
     }

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -226,7 +226,7 @@ export class APIStack extends cdk.Stack {
     if (provisionedConcurrency > 0) {
       const quoteTarget = new aws_asg.ScalableTarget(this, 'QuoteProvConcASG', {
         serviceNamespace: aws_asg.ServiceNamespace.LAMBDA,
-        maxCapacity: provisionedConcurrency * 5,
+        maxCapacity: provisionedConcurrency * 10,
         minCapacity: provisionedConcurrency,
         resourceId: `function:${quoteLambdaAlias.lambda.functionName}:${quoteLambdaAlias.aliasName}`,
         scalableDimension: 'lambda:function:ProvisionedConcurrency',


### PR DESCRIPTION
Context: https://www.notion.so/uniswaplabs/AWS-Lambda-Best-Practices-781917c67edf4dcb96d22e38a6e46411

Adjust provisioned concurrency for both lambdas to adjust from 50 to 500. This reduces the minimum amount (from 150 to 50) but still allows for a lot of leeway. Also, increasing the sensitivy of the alarm so it can increase faster

Almost all invocations are serviced by provisioned concurrencies so this just allows for more flexibility.
<img width="1010" alt="Screenshot 2024-02-05 at 21 25 55" src="https://github.com/Uniswap/unified-routing-api/assets/128516174/cb260db6-5626-450d-be04-bef11eda6fa4">


Link: https://us-east-2.console.aws.amazon.com/lambda/home?region=us-east-2#/functions/prod-us-east-2-UnifiedRoutingAPI-QuoteE2906A56-51nVLFinECLL/aliases/live?tab=monitoring




