### PR TITLE
fix: small portion cleanup

### DIFF
--- a/lib/entities/quote/ClassicQuote.ts
+++ b/lib/entities/quote/ClassicQuote.ts
@@ -207,7 +207,7 @@ export class ClassicQuote implements IQuote {
   }
 
   public get portion(): Portion | undefined {
-    if (!this.quoteData.portionBips || !this.quoteData.portionRecipient) return undefined;
+    if (this.quoteData.portionBips === undefined || this.quoteData.portionRecipient === undefined) return undefined;
 
     return {
       bips: this.quoteData.portionBips,

--- a/lib/entities/quote/ClassicQuote.ts
+++ b/lib/entities/quote/ClassicQuote.ts
@@ -6,6 +6,7 @@ import { PermitDetails, PermitSingleData, PermitTransferFromData } from '@uniswa
 import { v4 as uuidv4 } from 'uuid';
 import { QuoteRequest } from '..';
 import { RoutingType } from '../../constants';
+import { Portion, PortionType } from '../../fetchers/PortionFetcher';
 import { createPermitData } from '../../util/permit2';
 import { currentTimestampInMs, timestampInMstoSeconds } from '../../util/time';
 import { IQuote, LogJSON } from './index';
@@ -205,11 +206,13 @@ export class ClassicQuote implements IQuote {
     return this.request.info.slippageTolerance ? parseFloat(this.request.info.slippageTolerance) : -1;
   }
 
-  public getPortionBips(): number | undefined {
-    return this.quoteData.portionBips;
-  }
+  public get portion(): Portion | undefined {
+    if (!this.quoteData.portionBips || !this.quoteData.portionRecipient) return undefined;
 
-  public getPortionRecipient(): string | undefined {
-    return this.quoteData.portionRecipient;
+    return {
+      bips: this.quoteData.portionBips,
+      recipient: this.quoteData.portionRecipient,
+      type: PortionType.Flat,
+    };
   }
 }

--- a/lib/entities/quote/ClassicQuote.ts
+++ b/lib/entities/quote/ClassicQuote.ts
@@ -207,12 +207,14 @@ export class ClassicQuote implements IQuote {
   }
 
   public get portion(): Portion | undefined {
+    // we get the portion _type_ from the original classic URA request
+    // and merge it with the bips / recipient from the routing API quoteData
     if (this.quoteData.portionBips === undefined || this.quoteData.portionRecipient === undefined) return undefined;
 
     return {
       bips: this.quoteData.portionBips,
       recipient: this.quoteData.portionRecipient,
-      type: PortionType.Flat,
+      type: this.request.info.portion?.type ?? PortionType.Flat,
     };
   }
 }

--- a/lib/entities/quote/DutchQuote.ts
+++ b/lib/entities/quote/DutchQuote.ts
@@ -1,5 +1,5 @@
 import { TradeType } from '@uniswap/sdk-core';
-import { DutchOrder, DutchOrderBuilder, DutchOutput, DutchOrderInfoJSON } from '@uniswap/uniswapx-sdk';
+import { DutchOrder, DutchOrderBuilder, DutchOrderInfoJSON, DutchOutput } from '@uniswap/uniswapx-sdk';
 import { BigNumber, ethers } from 'ethers';
 
 import { PermitTransferFromData } from '@uniswap/permit2-sdk';
@@ -16,7 +16,7 @@ import {
   UNISWAPX_BASE_GAS,
   WETH_UNWRAP_GAS,
   WETH_WRAP_GAS,
-  WETH_WRAP_GAS_ALREADY_APPROVED
+  WETH_WRAP_GAS_ALREADY_APPROVED,
 } from '../../constants';
 import { Portion } from '../../fetchers/PortionFetcher';
 import { log } from '../../util/log';
@@ -27,7 +27,7 @@ import { LogJSON } from './index';
 
 export type DutchQuoteDerived = {
   largeTrade: boolean;
-}
+};
 
 export type DutchQuoteDataJSON = {
   orderInfo: DutchOrderInfoJSON;
@@ -110,7 +110,7 @@ export class DutchQuote implements IQuote {
       DutchQuoteType.RFQ,
       body.filler,
       nonce,
-      portion,
+      portion
     );
   }
 
@@ -152,7 +152,7 @@ export class DutchQuote implements IQuote {
       DutchQuoteType.SYNTHETIC,
       NATIVE_ADDRESS, // synthetic quote has no filler
       generateRandomNonce(), // synthetic quote has no nonce
-      quote.portion,
+      quote.portion
     );
   }
 
@@ -246,8 +246,12 @@ export class DutchQuote implements IQuote {
       permitData: this.getPermitData(),
       // NOTE: important for URA to return 0 bps and amount, in case of no portion.
       // this is FE requirement
-      portionBips: frontendAndUraEnablePortion(this.request.info.sendPortionEnabled) ? this.portion?.bips ?? 0 : undefined,
-      portionAmount: frontendAndUraEnablePortion(this.request.info.sendPortionEnabled) ? this.portionAmountOutStart.toString() ?? '0' : undefined,
+      portionBips: frontendAndUraEnablePortion(this.request.info.sendPortionEnabled)
+        ? this.portion?.bips ?? 0
+        : undefined,
+      portionAmount: frontendAndUraEnablePortion(this.request.info.sendPortionEnabled)
+        ? this.portionAmountOutStart.toString() ?? '0'
+        : undefined,
       portionRecipient: this.portion?.recipient,
     };
   }
@@ -269,41 +273,18 @@ export class DutchQuote implements IQuote {
         endAmount: this.amountInEnd,
       });
 
-    if (this.portion?.recipient && this.portion?.bips && frontendAndUraEnablePortion(this.request.info.sendPortionEnabled)) {
-      if (this.request.info.type === TradeType.EXACT_INPUT) {
-        // Amount to swapper
-        builder.output({
-          token: this.tokenOut,
-          startAmount: this.amountOutStart.sub(this.portionAmountOutStart),
-          endAmount: this.amountOutEnd.sub(this.portionAmountOutEnd),
-          recipient: this.request.config.swapper,
-        });
-      } else if (this.request.info.type === TradeType.EXACT_OUTPUT) {
-        // Amount to swapper
-        builder.output({
-          token: this.tokenOut,
-          startAmount: this.amountOutStart,
-          endAmount: this.amountOutEnd,
-          recipient: this.request.config.swapper,
-        });
-      }
-
-      // Amount to portion recipient
-      builder.output({
-        token: this.tokenOut,
-        startAmount: this.portionAmountOutStart,
-        endAmount: this.portionAmountOutEnd,
-        recipient: this.portion?.recipient,
-      });
-    } else {
-      // Amount to swapper
-      builder.output({
+    const outputs = getPortionAdjustedOutputs(
+      {
         token: this.tokenOut,
         startAmount: this.amountOutStart,
         endAmount: this.amountOutEnd,
         recipient: this.request.config.swapper,
-      });
-    }
+      },
+      !!this.request.info.sendPortionEnabled,
+      this.request.info.type,
+      this.portion
+    );
+    outputs.forEach((output) => builder.output(output));
 
     if (this.isExclusiveQuote() && this.filler) {
       builder.exclusiveFiller(this.filler, BigNumber.from(this.request.config.exclusivityOverrideBps));
@@ -325,9 +306,11 @@ export class DutchQuote implements IQuote {
       endAmountIn: this.amountInEnd.toString(),
       endAmountOut: this.amountOutEnd.toString(),
       amountInGasAdjusted: this.amountInStart.toString(),
-      amountInGasAndPortionAdjusted: this.request.info.type === TradeType.EXACT_OUTPUT ? this.amountInGasAndPortionAdjusted.toString() : undefined,
+      amountInGasAndPortionAdjusted:
+        this.request.info.type === TradeType.EXACT_OUTPUT ? this.amountInGasAndPortionAdjusted.toString() : undefined,
       amountOutGasAdjusted: this.amountOutStart.toString(),
-      amountOutGasAndPortionAdjusted: this.request.info.type === TradeType.EXACT_INPUT ? this.amountOutGasAndPortionAdjusted.toString() : undefined,
+      amountOutGasAndPortionAdjusted:
+        this.request.info.type === TradeType.EXACT_INPUT ? this.amountOutGasAndPortionAdjusted.toString() : undefined,
       swapper: this.swapper,
       filler: this.filler,
       routing: RoutingType[this.routingType],
@@ -550,35 +533,48 @@ export class DutchQuote implements IQuote {
   }
 }
 
-export function getPortionAdjustedOutputs(portion?: Portion, sendPortionEnabled: boolean, tradeType: TradeType, baseOutput: DutchOutput): DutchOutput[] {
+// baseOutput is the output that we would use for the swapper if no portion
+// returns list of outputs including portion
+export function getPortionAdjustedOutputs(
+  baseOutput: DutchOutput,
+  sendPortionEnabled: boolean,
+  tradeType: TradeType,
+  portion?: Portion
+): DutchOutput[] {
   if (portion === undefined || !sendPortionEnabled) return [baseOutput];
+  const portionStartAmount = baseOutput.startAmount.mul(portion.bips).div(BPS);
+  const portionEndAmount = baseOutput.endAmount.mul(portion.bips).div(BPS);
 
   const outputs: DutchOutput[] = [];
+
+  // Output to swapper
   if (tradeType === TradeType.EXACT_INPUT) {
-    // Amount to swapper
     outputs.push({
-      token: this.tokenOut,
-      startAmount: this.amountOutStart.sub(this.portionAmountOutStart),
-      endAmount: this.amountOutEnd.sub(this.portionAmountOutEnd),
-      recipient: this.request.config.swapper,
+      token: baseOutput.token,
+      startAmount: baseOutput.startAmount.sub(portionStartAmount),
+      endAmount: baseOutput.endAmount.sub(portionEndAmount),
+      recipient: baseOutput.recipient,
     });
   } else if (tradeType === TradeType.EXACT_OUTPUT) {
     // Amount to swapper
+    // for exact output, we append portion rather than subtracting it from the base
     outputs.push({
-      token: this.tokenOut,
-      startAmount: this.amountOutStart,
-      endAmount: this.amountOutEnd,
-      recipient: this.request.config.swapper,
+      token: baseOutput.token,
+      startAmount: baseOutput.startAmount,
+      endAmount: baseOutput.endAmount,
+      recipient: baseOutput.recipient,
     });
   }
 
-  // Amount to portion recipient
+  // Output to portion recipient
   outputs.push({
-    token: this.tokenOut,
-    startAmount: this.portionAmountOutStart,
-    endAmount: this.portionAmountOutEnd,
-    recipient: this.portion?.recipient,
+    token: baseOutput.token,
+    startAmount: portionStartAmount,
+    endAmount: portionEndAmount,
+    recipient: portion.recipient,
   });
+
+  return outputs;
 }
 
 // parses a slippage tolerance as a percent string

--- a/lib/entities/quote/DutchQuote.ts
+++ b/lib/entities/quote/DutchQuote.ts
@@ -280,8 +280,8 @@ export class DutchQuote implements IQuote {
         endAmount: this.amountOutEnd,
         recipient: this.request.config.swapper,
       },
-      !!this.request.info.sendPortionEnabled,
       this.request.info.type,
+      this.request.info.sendPortionEnabled,
       this.portion
     );
     outputs.forEach((output) => builder.output(output));
@@ -537,11 +537,11 @@ export class DutchQuote implements IQuote {
 // returns list of outputs including portion
 export function getPortionAdjustedOutputs(
   baseOutput: DutchOutput,
-  sendPortionEnabled: boolean,
   tradeType: TradeType,
+  sendPortionEnabled?: boolean,
   portion?: Portion
 ): DutchOutput[] {
-  if (portion === undefined || !sendPortionEnabled) return [baseOutput];
+  if (portion === undefined || !frontendAndUraEnablePortion(sendPortionEnabled)) return [baseOutput];
   const portionStartAmount = baseOutput.startAmount.mul(portion.bips).div(BPS);
   const portionEndAmount = baseOutput.endAmount.mul(portion.bips).div(BPS);
 

--- a/test/integ/quote-classic.test.ts
+++ b/test/integ/quote-classic.test.ts
@@ -67,7 +67,7 @@ describe('quote', function () {
 
   before(async function () {
     baseTest = new BaseIntegrationTestSuite();
-    [alice,] = await baseTest.before();
+    [alice] = await baseTest.before();
     // Do any custom setup here for this test suite
 
     // Help with test flakiness by retrying.

--- a/test/unit/entities/DutchQuote.test.ts
+++ b/test/unit/entities/DutchQuote.test.ts
@@ -1,227 +1,158 @@
-import { TradeType } from '@uniswap/sdk-core';
-import Logger from 'bunyan';
-import { BigNumber, ethers } from 'ethers';
-import * as _ from 'lodash';
+  import { TradeType } from '@uniswap/sdk-core';
+  import Logger from 'bunyan';
+  import { BigNumber, ethers } from 'ethers';
+  import * as _ from 'lodash';
 
-import { it } from '@jest/globals';
-import { BPS, DEFAULT_START_TIME_BUFFER_SECS, OPEN_QUOTE_START_TIME_BUFFER_SECS } from '../../../lib/constants';
-import { ClassicQuote, DutchQuote, DutchQuoteJSON } from '../../../lib/entities';
-import {
-  AMOUNT,
-  AMOUNT_LARGE,
-  DL_PERMIT_RFQ,
-  DUTCH_LIMIT_ORDER_JSON,
-  DUTCH_LIMIT_ORDER_JSON_WITH_PORTION,
-  FLAT_PORTION,
-  PORTION_BIPS,
-  PORTION_RECIPIENT,
-} from '../../constants';
-import {
-  CLASSIC_QUOTE_EXACT_IN_LARGE,
-  CLASSIC_QUOTE_EXACT_IN_LARGE_GAS,
-  CLASSIC_QUOTE_EXACT_IN_LARGE_WITH_PORTION,
-  CLASSIC_QUOTE_EXACT_IN_NATIVE,
-  CLASSIC_QUOTE_EXACT_IN_NATIVE_WITH_PORTION,
-  CLASSIC_QUOTE_EXACT_IN_SMALL,
-  CLASSIC_QUOTE_EXACT_OUT_LARGE,
-  createClassicQuote,
-  createDutchQuote,
-  createDutchQuoteWithRequest,
-  DL_QUOTE_EXACT_IN_LARGE,
-  DL_QUOTE_EXACT_IN_LARGE_WITH_PORTION,
-  DL_QUOTE_EXACT_OUT_LARGE,
-  DL_QUOTE_NATIVE_EXACT_IN_LARGE,
-  DL_QUOTE_NATIVE_EXACT_IN_LARGE_WITH_PORTION,
-} from '../../utils/fixtures';
+  import { it } from '@jest/globals';
+  import { BPS, DEFAULT_START_TIME_BUFFER_SECS, OPEN_QUOTE_START_TIME_BUFFER_SECS } from '../../../lib/constants';
+  import { ClassicQuote, DutchQuote, DutchQuoteJSON } from '../../../lib/entities';
+  import {
+    AMOUNT,
+    AMOUNT_LARGE,
+    DL_PERMIT_RFQ,
+    DUTCH_LIMIT_ORDER_JSON,
+    DUTCH_LIMIT_ORDER_JSON_WITH_PORTION,
+    FLAT_PORTION,
+    PORTION_BIPS,
+    PORTION_RECIPIENT,
+  } from '../../constants';
+  import {
+    CLASSIC_QUOTE_EXACT_IN_LARGE,
+    CLASSIC_QUOTE_EXACT_IN_LARGE_GAS,
+    CLASSIC_QUOTE_EXACT_IN_LARGE_WITH_PORTION,
+    CLASSIC_QUOTE_EXACT_IN_NATIVE,
+    CLASSIC_QUOTE_EXACT_IN_NATIVE_WITH_PORTION,
+    CLASSIC_QUOTE_EXACT_IN_SMALL,
+    CLASSIC_QUOTE_EXACT_OUT_LARGE,
+    createClassicQuote,
+    createDutchQuote,
+    createDutchQuoteWithRequest,
+    DL_QUOTE_EXACT_IN_LARGE,
+    DL_QUOTE_EXACT_IN_LARGE_WITH_PORTION,
+    DL_QUOTE_EXACT_OUT_LARGE,
+    DL_QUOTE_NATIVE_EXACT_IN_LARGE,
+    DL_QUOTE_NATIVE_EXACT_IN_LARGE_WITH_PORTION,
+  } from '../../utils/fixtures';
 
-describe('DutchQuote', () => {
-  // silent logger in tests
-  const logger = Logger.createLogger({ name: 'test' });
-  logger.level(Logger.FATAL);
+  describe('DutchQuote', () => {
+    // silent logger in tests
+    const logger = Logger.createLogger({ name: 'test' });
+    logger.level(Logger.FATAL);
 
-  beforeEach(() => {
-    process.env.ENABLE_PORTION = 'true';
-  });
-
-  afterEach(() => {
-    process.env.ENABLE_PORTION = 'false';
-  });
-
-  describe('Reparameterize', () => {
-    it('slippage is in percent terms', async () => {
-      const amountIn = BigNumber.from('1000000000');
-      const { amountIn: amountInEnd, amountOut: amountOutEnd } = DutchQuote.applySlippage(
-        { amountIn, amountOut: amountIn },
-        Object.assign({}, DL_QUOTE_EXACT_IN_LARGE.request, {
-          info: {
-            ...DL_QUOTE_EXACT_IN_LARGE.request.info,
-            slippageTolerance: 10,
-          },
-        })
-      );
-
-      expect(amountInEnd).toEqual(amountIn);
-      expect(amountOutEnd).toEqual(amountIn.mul(90).div(100));
+    beforeEach(() => {
+      process.env.ENABLE_PORTION = 'true';
     });
 
-    it('adjustments should always decrease outputs for exactIn', async () => {
-      const quote = CLASSIC_QUOTE_EXACT_IN_LARGE_GAS;
-      const amountIn = quote.amountInGasAdjusted;
-      const amountOut = quote.amountOutGasAdjusted;
-      const { amountIn: amountInGasAdjusted, amountOut: amountOutGasAdjusted } = DutchQuote.applyGasAdjustment(
-        {
-          amountIn: amountIn,
-          amountOut: amountOut,
-        },
-        quote
-      );
-      expect(amountInGasAdjusted.eq(amountIn)).toBeTruthy();
-      expect(amountOutGasAdjusted.lt(amountOut)).toBeTruthy();
-      const { amountIn: amountInSlippageAdjusted, amountOut: amountOutSlippageAdjusted } = DutchQuote.applySlippage(
-        { amountIn: amountInGasAdjusted, amountOut: amountOutGasAdjusted },
-        DL_QUOTE_EXACT_IN_LARGE.request
-      );
-
-      expect(amountInSlippageAdjusted.eq(amountInGasAdjusted)).toBeTruthy();
-      expect(amountOutSlippageAdjusted.lt(amountOutGasAdjusted)).toBeTruthy();
+    afterEach(() => {
+      process.env.ENABLE_PORTION = 'false';
     });
 
-    it('adjustments should always increase inputs for exactOut', async () => {
-      const quote = CLASSIC_QUOTE_EXACT_OUT_LARGE;
-      const amountIn = quote.amountInGasAdjusted;
-      const amountOut = quote.amountOutGasAdjusted;
-      const { amountIn: amountInGasAdjusted, amountOut: amountOutGasAdjusted } = DutchQuote.applyGasAdjustment(
-        {
-          amountIn: amountIn,
-          amountOut: amountOut,
-        },
-        quote
-      );
-      expect(amountInGasAdjusted.gt(amountIn)).toBeTruthy();
-      expect(amountOutGasAdjusted.eq(amountOut)).toBeTruthy();
-      const { amountIn: amountInSlippageAdjusted, amountOut: amountOutSlippageAdjusted } = DutchQuote.applySlippage(
-        { amountIn: amountInGasAdjusted, amountOut: amountOutGasAdjusted },
-        DL_QUOTE_EXACT_OUT_LARGE.request
-      );
-
-      expect(amountInSlippageAdjusted.gte(amountInGasAdjusted)).toBeTruthy();
-      expect(amountOutSlippageAdjusted.eq(amountOutGasAdjusted)).toBeTruthy();
-    });
-
-    it.each([
-      { title: 'overrides', largeTrade: true },
-      { title: 'does not override', largeTrade: false },
-    ])('$title auctionPeriodSec if order size is considered large: $largeTrade', async (params) => {
-      const classic = params.largeTrade ? CLASSIC_QUOTE_EXACT_IN_LARGE : CLASSIC_QUOTE_EXACT_IN_SMALL;
-      const reparamatrized = DutchQuote.reparameterize(DL_QUOTE_EXACT_IN_LARGE, classic, {
-        hasApprovedPermit2: true,
-        largeTrade: params.largeTrade,
-      });
-      if (params.largeTrade) {
-        expect(reparamatrized.auctionPeriodSecs).toEqual(120);
-      } else {
-        expect(reparamatrized.auctionPeriodSecs).toEqual(60);
-      }
-    });
-
-    it.each([true, false])(
-      `Does not reparameterize if classic is not defined with portion flag %p`,
-      async (enablePortion) => {
-        const dutchLargeQuote = enablePortion ? DL_QUOTE_EXACT_IN_LARGE_WITH_PORTION : DL_QUOTE_EXACT_IN_LARGE;
-        const reparameterized = DutchQuote.reparameterize(dutchLargeQuote, undefined, undefined);
-        expect(reparameterized).toMatchObject(dutchLargeQuote);
-
-        if (enablePortion) {
-          expect(reparameterized.portionBips).toEqual(PORTION_BIPS);
-          expect(reparameterized.portionRecipient).toEqual(PORTION_RECIPIENT);
-        }
-      }
-    );
-
-    it('only override auctionPeriodSec on mainnet', async () => {
-      const classic = CLASSIC_QUOTE_EXACT_IN_LARGE;
-      const dutchRequest = createDutchQuote({ amountOut: AMOUNT_LARGE, chainId: 137 }, 'EXACT_INPUT', '1');
-      const reparamatrized = DutchQuote.reparameterize(dutchRequest, classic);
-      expect(reparamatrized.auctionPeriodSecs).toEqual(60);
-    });
-
-    it.each([true, false])('reparameterizes with classic quote for end with portion flag %p', async (enablePortion) => {
-      const classicQuote = enablePortion ? CLASSIC_QUOTE_EXACT_IN_LARGE_WITH_PORTION : CLASSIC_QUOTE_EXACT_IN_LARGE;
-      const dutchQuote = enablePortion ? DL_QUOTE_EXACT_IN_LARGE_WITH_PORTION : DL_QUOTE_EXACT_IN_LARGE;
-      const reparameterized = DutchQuote.reparameterize(dutchQuote, classicQuote);
-      expect(reparameterized.request).toMatchObject(dutchQuote.request);
-      expect(reparameterized.amountInStart).toEqual(dutchQuote.amountInStart);
-      expect(reparameterized.amountOutStart).toEqual(dutchQuote.amountOutStart);
-
-      const { amountIn: amountInClassic, amountOut: amountOutClassic } = DutchQuote.applyGasAdjustment(
-        {
-          amountIn: classicQuote.amountInGasAdjusted,
-          amountOut: classicQuote.amountOutGasAdjusted,
-        },
-        classicQuote
-      );
-      const { amountIn: amountInEnd, amountOut: amountOutEnd } = DutchQuote.applySlippage(
-        { amountIn: amountInClassic, amountOut: amountOutClassic },
-        DL_QUOTE_EXACT_IN_LARGE.request
-      );
-
-      expect(reparameterized.amountInEnd).toEqual(amountInEnd);
-      expect(reparameterized.amountOutEnd).toEqual(amountOutEnd);
-
-      if (enablePortion) {
-        expect(reparameterized.portionBips).toEqual(PORTION_BIPS);
-        expect(reparameterized.portionRecipient).toEqual(PORTION_RECIPIENT);
-        expect(reparameterized.portionAmountOutStart).toEqual(
-          reparameterized.amountOutStart.mul(PORTION_BIPS).div(BPS)
+    describe('Reparameterize', () => {
+      it('slippage is in percent terms', async () => {
+        const amountIn = BigNumber.from('1000000000');
+        const { amountIn: amountInEnd, amountOut: amountOutEnd } = DutchQuote.applySlippage(
+          { amountIn, amountOut: amountIn },
+          Object.assign({}, DL_QUOTE_EXACT_IN_LARGE.request, {
+            info: {
+              ...DL_QUOTE_EXACT_IN_LARGE.request.info,
+              slippageTolerance: 10,
+            },
+          })
         );
-        expect(reparameterized.portionAmountOutEnd).toEqual(amountOutEnd.mul(PORTION_BIPS).div(BPS));
-      }
-    });
 
-    it.each([true, false])(
-      'reparameterizes with classic quote for end exactOutput with portion flag %p',
-      async (enablePortion) => {
+        expect(amountInEnd).toEqual(amountIn);
+        expect(amountOutEnd).toEqual(amountIn.mul(90).div(100));
+      });
+
+      it('adjustments should always decrease outputs for exactIn', async () => {
+        const quote = CLASSIC_QUOTE_EXACT_IN_LARGE_GAS;
+        const amountIn = quote.amountInGasAdjusted;
+        const amountOut = quote.amountOutGasAdjusted;
+        const { amountIn: amountInGasAdjusted, amountOut: amountOutGasAdjusted } = DutchQuote.applyGasAdjustment(
+          {
+            amountIn: amountIn,
+            amountOut: amountOut,
+          },
+          quote
+        );
+        expect(amountInGasAdjusted.eq(amountIn)).toBeTruthy();
+        expect(amountOutGasAdjusted.lt(amountOut)).toBeTruthy();
+        const { amountIn: amountInSlippageAdjusted, amountOut: amountOutSlippageAdjusted } = DutchQuote.applySlippage(
+          { amountIn: amountInGasAdjusted, amountOut: amountOutGasAdjusted },
+          DL_QUOTE_EXACT_IN_LARGE.request
+        );
+
+        expect(amountInSlippageAdjusted.eq(amountInGasAdjusted)).toBeTruthy();
+        expect(amountOutSlippageAdjusted.lt(amountOutGasAdjusted)).toBeTruthy();
+      });
+
+      it('adjustments should always increase inputs for exactOut', async () => {
+        const quote = CLASSIC_QUOTE_EXACT_OUT_LARGE;
+        const amountIn = quote.amountInGasAdjusted;
+        const amountOut = quote.amountOutGasAdjusted;
+        const { amountIn: amountInGasAdjusted, amountOut: amountOutGasAdjusted } = DutchQuote.applyGasAdjustment(
+          {
+            amountIn: amountIn,
+            amountOut: amountOut,
+          },
+          quote
+        );
+        expect(amountInGasAdjusted.gt(amountIn)).toBeTruthy();
+        expect(amountOutGasAdjusted.eq(amountOut)).toBeTruthy();
+        const { amountIn: amountInSlippageAdjusted, amountOut: amountOutSlippageAdjusted } = DutchQuote.applySlippage(
+          { amountIn: amountInGasAdjusted, amountOut: amountOutGasAdjusted },
+          DL_QUOTE_EXACT_OUT_LARGE.request
+        );
+
+        expect(amountInSlippageAdjusted.gte(amountInGasAdjusted)).toBeTruthy();
+        expect(amountOutSlippageAdjusted.eq(amountOutGasAdjusted)).toBeTruthy();
+      });
+
+      it.each([
+        { title: 'overrides', largeTrade: true },
+        { title: 'does not override', largeTrade: false },
+      ])('$title auctionPeriodSec if order size is considered large: $largeTrade', async (params) => {
+        const classic = params.largeTrade ? CLASSIC_QUOTE_EXACT_IN_LARGE : CLASSIC_QUOTE_EXACT_IN_SMALL;
+        const reparamatrized = DutchQuote.reparameterize(DL_QUOTE_EXACT_IN_LARGE, classic, {
+          hasApprovedPermit2: true,
+          largeTrade: params.largeTrade,
+        });
+        if (params.largeTrade) {
+          expect(reparamatrized.auctionPeriodSecs).toEqual(120);
+        } else {
+          expect(reparamatrized.auctionPeriodSecs).toEqual(60);
+        }
+      });
+
+      it.each([true, false])(
+        `Does not reparameterize if classic is not defined with portion flag %p`,
+        async (enablePortion) => {
+          const dutchLargeQuote = enablePortion ? DL_QUOTE_EXACT_IN_LARGE_WITH_PORTION : DL_QUOTE_EXACT_IN_LARGE;
+          const reparameterized = DutchQuote.reparameterize(dutchLargeQuote, undefined, undefined);
+          expect(reparameterized).toMatchObject(dutchLargeQuote);
+
+          if (enablePortion) {
+            expect(reparameterized.portion?.bips).toEqual(PORTION_BIPS);
+            expect(reparameterized.portion?.recipient).toEqual(PORTION_RECIPIENT);
+          }
+        }
+      );
+
+      it('only override auctionPeriodSec on mainnet', async () => {
+        const classic = CLASSIC_QUOTE_EXACT_IN_LARGE;
+        const dutchRequest = createDutchQuote({ amountOut: AMOUNT_LARGE, chainId: 137 }, 'EXACT_INPUT', '1');
+        const reparamatrized = DutchQuote.reparameterize(dutchRequest, classic);
+        expect(reparamatrized.auctionPeriodSecs).toEqual(60);
+      });
+
+      it.each([true, false])('reparameterizes with classic quote for end with portion flag %p', async (enablePortion) => {
         const classicQuote = enablePortion ? CLASSIC_QUOTE_EXACT_IN_LARGE_WITH_PORTION : CLASSIC_QUOTE_EXACT_IN_LARGE;
         const dutchQuote = enablePortion ? DL_QUOTE_EXACT_IN_LARGE_WITH_PORTION : DL_QUOTE_EXACT_IN_LARGE;
         const reparameterized = DutchQuote.reparameterize(dutchQuote, classicQuote);
         expect(reparameterized.request).toMatchObject(dutchQuote.request);
-
-        const { amountIn: amountInClassic, amountOut: amountOutClassic } = DutchQuote.applyGasAdjustment(
-          {
-            amountIn: classicQuote.amountInGasAdjusted,
-            amountOut: classicQuote.amountOutGasAdjusted,
-          },
-          classicQuote
-        );
-        const { amountIn: amountInEnd, amountOut: amountOutEnd } = DutchQuote.applySlippage(
-          { amountIn: amountInClassic, amountOut: amountOutClassic },
-          dutchQuote.request
-        );
-
-        expect(reparameterized.amountInEnd).toEqual(amountInEnd);
-        expect(reparameterized.amountOutEnd).toEqual(amountOutEnd);
         expect(reparameterized.amountInStart).toEqual(dutchQuote.amountInStart);
         expect(reparameterized.amountOutStart).toEqual(dutchQuote.amountOutStart);
 
-        if (enablePortion) {
-          expect(reparameterized.portionBips).toEqual(PORTION_BIPS);
-          expect(reparameterized.portionRecipient).toEqual(PORTION_RECIPIENT);
-          expect(reparameterized.portionAmountOutStart).toEqual(dutchQuote.amountOutStart.mul(PORTION_BIPS).div(BPS));
-          expect(reparameterized.portionAmountOutEnd).toEqual(amountOutEnd.mul(PORTION_BIPS).div(BPS));
-        }
-      }
-    );
-
-    it.each([true, false])(
-      'reparameterizes with wrap factored into startAmount with portion flag %p',
-      async (enablePortion) => {
-        const classicQuote = (
-          enablePortion ? CLASSIC_QUOTE_EXACT_IN_NATIVE_WITH_PORTION : CLASSIC_QUOTE_EXACT_IN_NATIVE
-        ) as ClassicQuote;
-        const dutchQuote = enablePortion ? DL_QUOTE_NATIVE_EXACT_IN_LARGE_WITH_PORTION : DL_QUOTE_NATIVE_EXACT_IN_LARGE;
-        const reparameterized = DutchQuote.reparameterize(dutchQuote, classicQuote);
-        expect(reparameterized.request).toMatchObject(dutchQuote.request);
-
         const { amountIn: amountInClassic, amountOut: amountOutClassic } = DutchQuote.applyGasAdjustment(
           {
             amountIn: classicQuote.amountInGasAdjusted,
@@ -231,180 +162,249 @@ describe('DutchQuote', () => {
         );
         const { amountIn: amountInEnd, amountOut: amountOutEnd } = DutchQuote.applySlippage(
           { amountIn: amountInClassic, amountOut: amountOutClassic },
-          dutchQuote.request
+          DL_QUOTE_EXACT_IN_LARGE.request
         );
 
-        expect(reparameterized.amountInStart).toEqual(dutchQuote.amountInStart);
-        expect(reparameterized.amountOutStart.lte(dutchQuote.amountOutStart)).toBeTruthy();
         expect(reparameterized.amountInEnd).toEqual(amountInEnd);
         expect(reparameterized.amountOutEnd).toEqual(amountOutEnd);
 
         if (enablePortion) {
-          expect(reparameterized.portionBips).toEqual(PORTION_BIPS);
-          expect(reparameterized.portionRecipient).toEqual(PORTION_RECIPIENT);
+          expect(reparameterized.portion?.bips).toEqual(PORTION_BIPS);
+          expect(reparameterized.portion?.recipient).toEqual(PORTION_RECIPIENT);
           expect(reparameterized.portionAmountOutStart).toEqual(
             reparameterized.amountOutStart.mul(PORTION_BIPS).div(BPS)
           );
           expect(reparameterized.portionAmountOutEnd).toEqual(amountOutEnd.mul(PORTION_BIPS).div(BPS));
         }
-      }
-    );
-  });
-
-  describe('decay parameters', () => {
-    it('uses default parameters - RFQ', () => {
-      const quote = createDutchQuoteWithRequest(
-        { filler: '0x1111111111111111111111111111111111111111' },
-        {},
-        {
-          swapper: '0x9999999999999999999999999999999999999999',
-          startTimeBufferSecs: undefined,
-          auctionPeriodSecs: undefined,
-          deadlineBufferSecs: undefined,
-        }
-      );
-      const result = quote.toJSON();
-      expect(result.startTimeBufferSecs).toEqual(DEFAULT_START_TIME_BUFFER_SECS);
-      expect(result.auctionPeriodSecs).toEqual(60);
-      expect(result.deadlineBufferSecs).toEqual(12);
-    });
-
-    it('uses default parameters - Open', () => {
-      const quote = createDutchQuoteWithRequest(
-        { filler: '0x0000000000000000000000000000000000000000' },
-        {},
-        {
-          swapper: '0x9999999999999999999999999999999999999999',
-          startTimeBufferSecs: undefined,
-          auctionPeriodSecs: undefined,
-          deadlineBufferSecs: undefined,
-        }
-      );
-      const result = quote.toJSON();
-      expect(result.startTimeBufferSecs).toEqual(OPEN_QUOTE_START_TIME_BUFFER_SECS);
-      expect(result.auctionPeriodSecs).toEqual(60);
-      expect(result.deadlineBufferSecs).toEqual(12);
-    });
-
-    it('uses default parameters - polygon', () => {
-      const quote = createDutchQuoteWithRequest(
-        { filler: '0x0000000000000000000000000000000000000000', chainId: 137 },
-        {
-          tokenInChainId: 137,
-          tokenOutChainId: 137,
-        },
-        {
-          swapper: '0x9999999999999999999999999999999999999999',
-          startTimeBufferSecs: undefined,
-          auctionPeriodSecs: undefined,
-          deadlineBufferSecs: undefined,
-        }
-      );
-      const result = quote.toJSON();
-      expect(result.startTimeBufferSecs).toEqual(OPEN_QUOTE_START_TIME_BUFFER_SECS);
-      expect(result.auctionPeriodSecs).toEqual(60);
-      expect(result.deadlineBufferSecs).toEqual(5);
-    });
-
-    it('overrides parameters in request', () => {
-      const quote = createDutchQuoteWithRequest(
-        { filler: '0x1111111111111111111111111111111111111111' },
-        {},
-        {
-          swapper: '0x9999999999999999999999999999999999999999',
-          startTimeBufferSecs: 111,
-          auctionPeriodSecs: 222,
-          deadlineBufferSecs: 333,
-        }
-      );
-      const result = quote.toJSON();
-      expect(result.startTimeBufferSecs).toEqual(111);
-      expect(result.auctionPeriodSecs).toEqual(222);
-      expect(result.deadlineBufferSecs).toEqual(333);
-    });
-  });
-
-  describe('getPermit', () => {
-    it('Succeeds - Basic', () => {
-      jest.useFakeTimers({
-        now: 0,
       });
-      const quote = createDutchQuote(
-        { amountOut: AMOUNT_LARGE, filler: '0x1111111111111111111111111111111111111111' },
-        'EXACT_INPUT'
-      ) as any;
-      quote.nonce = 1;
-      const dlQuote = quote as DutchQuote;
-      const result = dlQuote.getPermitData();
-      const expected = DL_PERMIT_RFQ;
-      expect(_.isEqual(JSON.stringify(result), JSON.stringify(expected))).toBe(true);
-      jest.clearAllTimers();
-    });
-  });
 
-  describe('toJSON', () => {
-    it.each([true, false])('Succeeds - Basic with portion flag %p', (enablePortion) => {
-      const quote = createDutchQuote(
-        { amountOut: '10000', filler: '0x1111111111111111111111111111111111111111' },
-        'EXACT_INPUT',
-        '1',
-        enablePortion ? FLAT_PORTION : undefined,
-        enablePortion
-      ) as any;
-      const result = quote.toJSON();
-      expect(result).toMatchObject(enablePortion ? DUTCH_LIMIT_ORDER_JSON_WITH_PORTION : DUTCH_LIMIT_ORDER_JSON);
-    });
-  });
+      it.each([true, false])(
+        'reparameterizes with classic quote for end exactOutput with portion flag %p',
+        async (enablePortion) => {
+          const classicQuote = enablePortion ? CLASSIC_QUOTE_EXACT_IN_LARGE_WITH_PORTION : CLASSIC_QUOTE_EXACT_IN_LARGE;
+          const dutchQuote = enablePortion ? DL_QUOTE_EXACT_IN_LARGE_WITH_PORTION : DL_QUOTE_EXACT_IN_LARGE;
+          const reparameterized = DutchQuote.reparameterize(dutchQuote, classicQuote);
+          expect(reparameterized.request).toMatchObject(dutchQuote.request);
 
-  describe('fromClassicQuote', () => {
-    it.each([true, false])('Succeeds - Generates nonce on initialization with portion flag %p', (enablePortion) => {
-      const classicQuote = createClassicQuote(
-        (enablePortion && { portionBips: PORTION_BIPS, portionRecipient: PORTION_RECIPIENT }) || {},
-        {}
+          const { amountIn: amountInClassic, amountOut: amountOutClassic } = DutchQuote.applyGasAdjustment(
+            {
+              amountIn: classicQuote.amountInGasAdjusted,
+              amountOut: classicQuote.amountOutGasAdjusted,
+            },
+            classicQuote
+          );
+          const { amountIn: amountInEnd, amountOut: amountOutEnd } = DutchQuote.applySlippage(
+            { amountIn: amountInClassic, amountOut: amountOutClassic },
+            dutchQuote.request
+          );
+
+          expect(reparameterized.amountInEnd).toEqual(amountInEnd);
+          expect(reparameterized.amountOutEnd).toEqual(amountOutEnd);
+          expect(reparameterized.amountInStart).toEqual(dutchQuote.amountInStart);
+          expect(reparameterized.amountOutStart).toEqual(dutchQuote.amountOutStart);
+
+          if (enablePortion) {
+            expect(reparameterized.portion?.bips).toEqual(PORTION_BIPS);
+            expect(reparameterized.portion?.recipient).toEqual(PORTION_RECIPIENT);
+            expect(reparameterized.portionAmountOutStart).toEqual(dutchQuote.amountOutStart.mul(PORTION_BIPS).div(BPS));
+            expect(reparameterized.portionAmountOutEnd).toEqual(amountOutEnd.mul(PORTION_BIPS).div(BPS));
+          }
+        }
       );
-      const dutchQuote = createDutchQuote({}, 'EXACT_INPUT');
-      const result = DutchQuote.fromClassicQuote(dutchQuote.request, classicQuote);
-      const firstNonce = result.toOrder().info.nonce;
-      const secondNonce = result.toOrder().info.nonce;
-      expect(firstNonce).toEqual(secondNonce);
 
-      if (enablePortion) {
-        expect(result.portionBips).toEqual(PORTION_BIPS);
-        expect(result.portionRecipient).toEqual(PORTION_RECIPIENT);
-        expect(result.portionAmountOutStart).toEqual(result.amountOutStart.mul(PORTION_BIPS).div(BPS));
-        expect(result.portionAmountOutEnd).toEqual(result.amountOutEnd.mul(PORTION_BIPS).div(BPS));
-      }
+      it.each([true, false])(
+        'reparameterizes with wrap factored into startAmount with portion flag %p',
+        async (enablePortion) => {
+          const classicQuote = (
+            enablePortion ? CLASSIC_QUOTE_EXACT_IN_NATIVE_WITH_PORTION : CLASSIC_QUOTE_EXACT_IN_NATIVE
+          ) as ClassicQuote;
+          const dutchQuote = enablePortion ? DL_QUOTE_NATIVE_EXACT_IN_LARGE_WITH_PORTION : DL_QUOTE_NATIVE_EXACT_IN_LARGE;
+          const reparameterized = DutchQuote.reparameterize(dutchQuote, classicQuote);
+          expect(reparameterized.request).toMatchObject(dutchQuote.request);
+
+          const { amountIn: amountInClassic, amountOut: amountOutClassic } = DutchQuote.applyGasAdjustment(
+            {
+              amountIn: classicQuote.amountInGasAdjusted,
+              amountOut: classicQuote.amountOutGasAdjusted,
+            },
+            classicQuote
+          );
+          const { amountIn: amountInEnd, amountOut: amountOutEnd } = DutchQuote.applySlippage(
+            { amountIn: amountInClassic, amountOut: amountOutClassic },
+            dutchQuote.request
+          );
+
+          expect(reparameterized.amountInStart).toEqual(dutchQuote.amountInStart);
+          expect(reparameterized.amountOutStart.lte(dutchQuote.amountOutStart)).toBeTruthy();
+          expect(reparameterized.amountInEnd).toEqual(amountInEnd);
+          expect(reparameterized.amountOutEnd).toEqual(amountOutEnd);
+
+          if (enablePortion) {
+            expect(reparameterized.portion?.bips).toEqual(PORTION_BIPS);
+            expect(reparameterized.portion?.recipient).toEqual(PORTION_RECIPIENT);
+            expect(reparameterized.portionAmountOutStart).toEqual(
+              reparameterized.amountOutStart.mul(PORTION_BIPS).div(BPS)
+            );
+            expect(reparameterized.portionAmountOutEnd).toEqual(amountOutEnd.mul(PORTION_BIPS).div(BPS));
+          }
+        }
+      );
     });
 
-    it.each([true, false])('applies gas adjustment to endAmount with portion flag %p', (enablePortion) => {
-      const amount = '10000000000000000';
-      const classicQuote = createClassicQuote(
-        (enablePortion && { amount: amount, portionBips: PORTION_BIPS, portionRecipient: PORTION_RECIPIENT }) || {
-          amount,
-        },
-        {}
-      );
-      const dutchQuote = createDutchQuote({ amountIn: amount }, 'EXACT_INPUT');
-      const result = DutchQuote.fromClassicQuote(dutchQuote.request, classicQuote);
-      const firstNonce = result.toOrder().info.nonce;
-      const secondNonce = result.toOrder().info.nonce;
-      expect(firstNonce).toEqual(secondNonce);
-      expect(result.amountInStart).toEqual(classicQuote.amountInGasAdjusted);
-      // greater because of price improvement
-      expect(result.amountOutStart.gt(classicQuote.amountOutGasAdjusted)).toBeTruthy();
+    describe('decay parameters', () => {
+      it('uses default parameters - RFQ', () => {
+        const quote = createDutchQuoteWithRequest(
+          { filler: '0x1111111111111111111111111111111111111111' },
+          {},
+          {
+            swapper: '0x9999999999999999999999999999999999999999',
+            startTimeBufferSecs: undefined,
+            auctionPeriodSecs: undefined,
+            deadlineBufferSecs: undefined,
+          }
+        );
+        const result = quote.toJSON();
+        expect(result.startTimeBufferSecs).toEqual(DEFAULT_START_TIME_BUFFER_SECS);
+        expect(result.auctionPeriodSecs).toEqual(60);
+        expect(result.deadlineBufferSecs).toEqual(12);
+      });
 
-      const { amountIn: slippageAdjustedAmountIn, amountOut: slippageAdjustedAmountOut } = DutchQuote.applySlippage(
-        { amountIn: result.amountInStart, amountOut: result.amountOutStart },
-        dutchQuote.request
-      );
-      expect(result.amountInEnd).toEqual(slippageAdjustedAmountIn);
-      expect(result.amountInEnd).toEqual(result.amountInStart);
-      // should have extra adjustment for gas to amountOut
-      expect(result.amountOutEnd.lte(slippageAdjustedAmountOut)).toBeTruthy();
+      it('uses default parameters - Open', () => {
+        const quote = createDutchQuoteWithRequest(
+          { filler: '0x0000000000000000000000000000000000000000' },
+          {},
+          {
+            swapper: '0x9999999999999999999999999999999999999999',
+            startTimeBufferSecs: undefined,
+            auctionPeriodSecs: undefined,
+            deadlineBufferSecs: undefined,
+          }
+        );
+        const result = quote.toJSON();
+        expect(result.startTimeBufferSecs).toEqual(OPEN_QUOTE_START_TIME_BUFFER_SECS);
+        expect(result.auctionPeriodSecs).toEqual(60);
+        expect(result.deadlineBufferSecs).toEqual(12);
+      });
 
-      if (enablePortion) {
-        expect(result.portionBips).toEqual(PORTION_BIPS);
-        expect(result.portionRecipient).toEqual(PORTION_RECIPIENT);
+      it('uses default parameters - polygon', () => {
+        const quote = createDutchQuoteWithRequest(
+          { filler: '0x0000000000000000000000000000000000000000', chainId: 137 },
+          {
+            tokenInChainId: 137,
+            tokenOutChainId: 137,
+          },
+          {
+            swapper: '0x9999999999999999999999999999999999999999',
+            startTimeBufferSecs: undefined,
+            auctionPeriodSecs: undefined,
+            deadlineBufferSecs: undefined,
+          }
+        );
+        const result = quote.toJSON();
+        expect(result.startTimeBufferSecs).toEqual(OPEN_QUOTE_START_TIME_BUFFER_SECS);
+        expect(result.auctionPeriodSecs).toEqual(60);
+        expect(result.deadlineBufferSecs).toEqual(5);
+      });
+
+      it('overrides parameters in request', () => {
+        const quote = createDutchQuoteWithRequest(
+          { filler: '0x1111111111111111111111111111111111111111' },
+          {},
+          {
+            swapper: '0x9999999999999999999999999999999999999999',
+            startTimeBufferSecs: 111,
+            auctionPeriodSecs: 222,
+            deadlineBufferSecs: 333,
+          }
+        );
+        const result = quote.toJSON();
+        expect(result.startTimeBufferSecs).toEqual(111);
+        expect(result.auctionPeriodSecs).toEqual(222);
+        expect(result.deadlineBufferSecs).toEqual(333);
+      });
+    });
+
+    describe('getPermit', () => {
+      it('Succeeds - Basic', () => {
+        jest.useFakeTimers({
+          now: 0,
+        });
+        const quote = createDutchQuote(
+          { amountOut: AMOUNT_LARGE, filler: '0x1111111111111111111111111111111111111111' },
+          'EXACT_INPUT'
+        ) as any;
+        quote.nonce = 1;
+        const dlQuote = quote as DutchQuote;
+        const result = dlQuote.getPermitData();
+        const expected = DL_PERMIT_RFQ;
+        expect(_.isEqual(JSON.stringify(result), JSON.stringify(expected))).toBe(true);
+        jest.clearAllTimers();
+      });
+    });
+
+    describe('toJSON', () => {
+      it.each([true, false])('Succeeds - Basic with portion flag %p', (enablePortion) => {
+        const quote = createDutchQuote(
+          { amountOut: '10000', filler: '0x1111111111111111111111111111111111111111' },
+          'EXACT_INPUT',
+          '1',
+          enablePortion ? FLAT_PORTION : undefined,
+          enablePortion
+        ) as any;
+        const result = quote.toJSON();
+        expect(result).toMatchObject(enablePortion ? DUTCH_LIMIT_ORDER_JSON_WITH_PORTION : DUTCH_LIMIT_ORDER_JSON);
+      });
+    });
+
+    describe('fromClassicQuote', () => {
+      it.each([true, false])('Succeeds - Generates nonce on initialization with portion flag %p', (enablePortion) => {
+        const classicQuote = createClassicQuote(
+          (enablePortion && { portionBips: PORTION_BIPS, portionRecipient: PORTION_RECIPIENT }) || {},
+          {}
+        );
+        const dutchQuote = createDutchQuote({}, 'EXACT_INPUT');
+        const result = DutchQuote.fromClassicQuote(dutchQuote.request, classicQuote);
+        const firstNonce = result.toOrder().info.nonce;
+        const secondNonce = result.toOrder().info.nonce;
+        expect(firstNonce).toEqual(secondNonce);
+
+        if (enablePortion) {
+          expect(result.portion?.bips).toEqual(PORTION_BIPS);
+          expect(result.portion?.recipient).toEqual(PORTION_RECIPIENT);
+          expect(result.portionAmountOutStart).toEqual(result.amountOutStart.mul(PORTION_BIPS).div(BPS));
+          expect(result.portionAmountOutEnd).toEqual(result.amountOutEnd.mul(PORTION_BIPS).div(BPS));
+        }
+      });
+
+      it.each([true, false])('applies gas adjustment to endAmount with portion flag %p', (enablePortion) => {
+        const amount = '10000000000000000';
+        const classicQuote = createClassicQuote(
+          (enablePortion && { amount: amount, portionBips: PORTION_BIPS, portionRecipient: PORTION_RECIPIENT }) || {
+            amount,
+          },
+          {}
+        );
+        const dutchQuote = createDutchQuote({ amountIn: amount }, 'EXACT_INPUT');
+        const result = DutchQuote.fromClassicQuote(dutchQuote.request, classicQuote);
+        const firstNonce = result.toOrder().info.nonce;
+        const secondNonce = result.toOrder().info.nonce;
+        expect(firstNonce).toEqual(secondNonce);
+        expect(result.amountInStart).toEqual(classicQuote.amountInGasAdjusted);
+        // greater because of price improvement
+        expect(result.amountOutStart.gt(classicQuote.amountOutGasAdjusted)).toBeTruthy();
+
+        const { amountIn: slippageAdjustedAmountIn, amountOut: slippageAdjustedAmountOut } = DutchQuote.applySlippage(
+          { amountIn: result.amountInStart, amountOut: result.amountOutStart },
+          dutchQuote.request
+        );
+        expect(result.amountInEnd).toEqual(slippageAdjustedAmountIn);
+        expect(result.amountInEnd).toEqual(result.amountInStart);
+        // should have extra adjustment for gas to amountOut
+        expect(result.amountOutEnd.lte(slippageAdjustedAmountOut)).toBeTruthy();
+
+        if (enablePortion) {
+          expect(result.portion?.bips).toEqual(PORTION_BIPS);
+          expect(result.portion?.recipient).toEqual(PORTION_RECIPIENT);
         expect(result.portionAmountOutStart).toEqual(result.amountOutStart.mul(PORTION_BIPS).div(BPS));
         expect(result.portionAmountOutEnd).toEqual(result.amountOutEnd.mul(PORTION_BIPS).div(BPS));
       }

--- a/test/unit/lib/entities/context/DutchQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/DutchQuoteContext.test.ts
@@ -616,7 +616,6 @@ describe('DutchQuoteContext', () => {
         ...rfqQuote,
         amountOutStart: expect.any(BigNumber),
         amountOutEnd: expect.any(BigNumber),
-        portionBips: 0,
         derived: {
           largeTrade: true,
         },
@@ -630,7 +629,6 @@ describe('DutchQuoteContext', () => {
         ...rfqQuote,
         amountOutStart: expect.any(BigNumber),
         amountOutEnd: expect.any(BigNumber),
-        portionBips: 0,
         derived: {
           largeTrade: true,
         },

--- a/test/unit/lib/entities/context/DutchQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/DutchQuoteContext.test.ts
@@ -616,6 +616,11 @@ describe('DutchQuoteContext', () => {
         ...rfqQuote,
         amountOutStart: expect.any(BigNumber),
         amountOutEnd: expect.any(BigNumber),
+        portion: {
+          bips: 0,
+          recipient: '0x0000000000000000000000000000000000000000',
+          type: 'flat',
+        },
         derived: {
           largeTrade: true,
         },
@@ -629,6 +634,11 @@ describe('DutchQuoteContext', () => {
         ...rfqQuote,
         amountOutStart: expect.any(BigNumber),
         amountOutEnd: expect.any(BigNumber),
+        portion: {
+          bips: 0,
+          recipient: '0x0000000000000000000000000000000000000000',
+          type: 'flat',
+        },
         derived: {
           largeTrade: true,
         },

--- a/test/unit/lib/entities/quoteResponse.test.ts
+++ b/test/unit/lib/entities/quoteResponse.test.ts
@@ -134,8 +134,8 @@ describe('QuoteResponse', () => {
     });
     expect(quote.amountIn.toString()).toEqual(CLASSIC_QUOTE_JSON.amount);
     expect(quote.amountOut.toString()).toEqual(CLASSIC_QUOTE_JSON.quote);
-    expect(quote.getPortionBips()).toEqual(CLASSIC_QUOTE_JSON.portionBips);
-    expect(quote.getPortionRecipient()).toEqual(CLASSIC_QUOTE_JSON.portionRecipient);
+    expect(quote.portion?.bips).toEqual(CLASSIC_QUOTE_JSON.portionBips);
+    expect(quote.portion?.recipient).toEqual(CLASSIC_QUOTE_JSON.portionRecipient);
   });
 
   it('parses classic quote exactOutput', () => {
@@ -149,7 +149,7 @@ describe('QuoteResponse', () => {
     });
     expect(quote.amountIn.toString()).toEqual(CLASSIC_QUOTE_JSON.quote);
     expect(quote.amountOut.toString()).toEqual(CLASSIC_QUOTE_JSON.amount);
-    expect(quote.getPortionBips()).toEqual(CLASSIC_QUOTE_JSON.portionBips);
-    expect(quote.getPortionRecipient()).toEqual(CLASSIC_QUOTE_JSON.portionRecipient);
+    expect(quote.portion?.bips).toEqual(CLASSIC_QUOTE_JSON.portionBips);
+    expect(quote.portion?.recipient).toEqual(CLASSIC_QUOTE_JSON.portionRecipient);
   });
 });

--- a/test/unit/providers/quoters/RfqQuoter.test.ts
+++ b/test/unit/providers/quoters/RfqQuoter.test.ts
@@ -172,8 +172,8 @@ describe('RfqQuoter test', () => {
         amountOutStart: BigNumber.from(AMOUNT),
       });
       expect(quote).toBeInstanceOf(DutchQuote);
-      expect((quote as DutchQuote).portionBips).toEqual(portionResponse.portion?.bips);
-      expect((quote as DutchQuote).portionRecipient).toEqual(portionResponse.portion?.recipient);
+      expect((quote as DutchQuote).portion?.bips).toEqual(portionResponse.portion?.bips);
+      expect((quote as DutchQuote).portion?.recipient).toEqual(portionResponse.portion?.recipient);
     });
 
     it('returns EXACT_INPUT quote with portion', async () => {
@@ -188,8 +188,8 @@ describe('RfqQuoter test', () => {
         amountOutStart: BigNumber.from(AMOUNT),
       });
       expect(quote).toBeInstanceOf(DutchQuote);
-      expect((quote as DutchQuote).portionBips).toEqual(portionResponse.portion?.bips);
-      expect((quote as DutchQuote).portionRecipient).toEqual(portionResponse.portion?.recipient);
+      expect((quote as DutchQuote).portion?.bips).toEqual(portionResponse.portion?.bips);
+      expect((quote as DutchQuote).portion?.recipient).toEqual(portionResponse.portion?.recipient);
 
       expect(
         postSpy({
@@ -232,8 +232,8 @@ describe('RfqQuoter test', () => {
         amountOutStart: BigNumber.from(AMOUNT),
       });
       expect(quote).toBeInstanceOf(DutchQuote);
-      expect((quote as DutchQuote).portionBips).toEqual(portionResponse.portion?.bips);
-      expect((quote as DutchQuote).portionRecipient).toEqual(portionResponse.portion?.recipient);
+      expect((quote as DutchQuote).portion?.bips).toEqual(portionResponse.portion?.bips);
+      expect((quote as DutchQuote).portion?.recipient).toEqual(portionResponse.portion?.recipient);
 
       expect(
         postSpy({

--- a/test/utils/fixtures.ts
+++ b/test/utils/fixtures.ts
@@ -272,7 +272,8 @@ export const CLASSIC_QUOTE_DATA = {
     permitNonce: '1',
     tradeType: 'exactIn',
     slippage: 0.5,
-    portionBips: 0, // always assume portion Bips will get returned from routing-api
+    portionBips: 0, // always assume portion will get returned from routing-api
+    portionRecipient: '0x0000000000000000000000000000000000000000',
   },
 };
 


### PR DESCRIPTION
- use portion object instead of raw fields inside quote objects
- smol helper to split a dutch output post fees, to be used to dedupe code b/t dutch order types