### PR TITLE
chore: pinning the gh action to a sha hash

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run swagger validation
-        uses: readmeio/rdme@v8
+        uses: readmeio/rdme@51a80867c45de15e2b41af0c4bd5bbc61b932804
         with:
           rdme: openapi:validate swagger.json


### PR DESCRIPTION
Minor change to pin the shaw hash for generating the docs