### PR TITLE
feat: add dutch v2 routing tpe

### DIFF
--- a/lib/entities/quote/DutchQuote.ts
+++ b/lib/entities/quote/DutchQuote.ts
@@ -305,7 +305,8 @@ export class DutchQuote implements IQuote {
       amountOut: this.amountOutStart.toString(),
       endAmountIn: this.amountInEnd.toString(),
       endAmountOut: this.amountOutEnd.toString(),
-      amountInGasAdjusted: this.request.info.type === TradeType.EXACT_OUTPUT ? this.amountInGasAdjusted.toString() : undefined,
+      amountInGasAdjusted:
+        this.request.info.type === TradeType.EXACT_OUTPUT ? this.amountInGasAdjusted.toString() : undefined,
       amountInGasAndPortionAdjusted:
         this.request.info.type === TradeType.EXACT_OUTPUT ? this.amountInGasAndPortionAdjusted.toString() : undefined,
       amountOutGasAdjusted: this.amountOutStart.toString(),

--- a/lib/entities/quote/DutchV2Quote.ts
+++ b/lib/entities/quote/DutchV2Quote.ts
@@ -1,6 +1,6 @@
 import { PermitTransferFromData } from '@uniswap/permit2-sdk';
 import { TradeType } from '@uniswap/sdk-core';
-import { UnsignedV2DutchOrder, V2DutchOrderBuilder, UnsignedV2DutchOrderInfoJSON } from '@uniswap/uniswapx-sdk';
+import { UnsignedV2DutchOrder, UnsignedV2DutchOrderInfoJSON, V2DutchOrderBuilder } from '@uniswap/uniswapx-sdk';
 import { BigNumber, ethers } from 'ethers';
 
 import { IQuote, LogJSON } from '.';

--- a/lib/util/validator.ts
+++ b/lib/util/validator.ts
@@ -75,7 +75,7 @@ export class FieldValidator {
   public static readonly quoteSpeed = Joi.string().valid('fast', 'standard');
 
   public static readonly classicConfig = Joi.object({
-    routingType: FieldValidator.routingType.required(),
+    routingType: Joi.string().valid('CLASSIC'),
     protocols: FieldValidator.protocols.required(),
     gasPriceWei: FieldValidator.gasPriceWei.optional(),
     simulateFromAddress: FieldValidator.address.optional(),
@@ -97,7 +97,7 @@ export class FieldValidator {
   });
 
   public static readonly dutchLimitConfig = Joi.object({
-    routingType: FieldValidator.routingType.required(),
+    routingType: Joi.string().valid('DUTCH_LIMIT'),
     swapper: FieldValidator.address.optional(),
     exclusivityOverrideBps: FieldValidator.positiveNumber.optional(),
     startTimeBufferSecs: FieldValidator.positiveNumber.optional(),
@@ -108,7 +108,7 @@ export class FieldValidator {
   });
 
   public static readonly dutchV2Config = Joi.object({
-    routingType: FieldValidator.routingType.required(),
+    routingType: Joi.string().valid('DUTCH_V2'),
     swapper: FieldValidator.address.optional(),
     deadlineBufferSecs: FieldValidator.positiveNumber.optional(),
     useSyntheticQuotes: Joi.boolean().optional(),

--- a/lib/util/validator.ts
+++ b/lib/util/validator.ts
@@ -38,7 +38,7 @@ export class FieldValidator {
 
   public static readonly tradeType = Joi.string().valid('EXACT_INPUT', 'EXACT_OUTPUT');
 
-  public static readonly routingType = Joi.string().valid('CLASSIC', 'DUTCH_LIMIT').messages({
+  public static readonly routingType = Joi.string().valid('CLASSIC', 'DUTCH_LIMIT', 'DUTCH_V2').messages({
     'any.only': 'Invalid routingType',
   });
 

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -41,6 +41,12 @@ export const DL_CONFIG = {
   auctionPeriodSecs: 60,
 };
 
+export const DUTCH_V2_CONFIG = {
+  routingType: RoutingType.DUTCH_V2,
+  swapper: SWAPPER,
+  deadlineBufferSecs: 24,
+};
+
 export const CLASSIC_CONFIG = {
   routingType: RoutingType.CLASSIC,
   protocols: ['V2', 'V3', 'MIXED'],

--- a/test/unit/lib/entities/quoteRequest.test.ts
+++ b/test/unit/lib/entities/quoteRequest.test.ts
@@ -159,7 +159,9 @@ describe('QuoteRequest', () => {
           const { quoteRequests: requests } = parseQuoteRequests(request);
           const dutchRequest = requests[0] as DutchV2Request;
 
-          expect(dutchRequest.toJSON()).toEqual(Object.assign({}, MOCK_DUTCH_V2_CONFIG_JSON, { useSyntheticQuotes: false }));
+          expect(dutchRequest.toJSON()).toEqual(
+            Object.assign({}, MOCK_DUTCH_V2_CONFIG_JSON, { useSyntheticQuotes: false })
+          );
         });
 
         it('parses basic classic quote order config properly', () => {

--- a/test/unit/lib/handlers/quote/schema.test.ts
+++ b/test/unit/lib/handlers/quote/schema.test.ts
@@ -51,7 +51,7 @@ describe('Post quote request validation', () => {
     it('should reject dutch v2 config as dutch v1', () => {
       const { error } = FieldValidator.dutchLimitConfig.validate(DUTCH_V2_CONFIG_JSON);
       expect(error).toBeDefined();
-      expect(error?.message).toEqual('\"routingType\" must be [DUTCH_LIMIT]');
+      expect(error?.message).toEqual('"routingType" must be [DUTCH_LIMIT]');
     });
 
     it('should reject invalid routingType', () => {
@@ -60,7 +60,7 @@ describe('Post quote request validation', () => {
         routingType: 'INVALID',
       });
       expect(error).toBeDefined();
-      expect(error?.message).toEqual('\"routingType\" must be [DUTCH_LIMIT]');
+      expect(error?.message).toEqual('"routingType" must be [DUTCH_LIMIT]');
     });
 
     it('should reject invalid slippage', () => {
@@ -98,7 +98,7 @@ describe('Post quote request validation', () => {
         routingType: 'INVALID',
       });
       expect(error).toBeDefined();
-      expect(error?.message).toEqual('\"routingType\" must be [CLASSIC]');
+      expect(error?.message).toEqual('"routingType" must be [CLASSIC]');
     });
 
     it('should reject invalid protocols', () => {

--- a/test/unit/lib/handlers/quote/schema.test.ts
+++ b/test/unit/lib/handlers/quote/schema.test.ts
@@ -44,8 +44,14 @@ describe('Post quote request validation', () => {
     });
 
     it('should validate dutch v2 config', () => {
-      const { error } = FieldValidator.dutchLimitConfig.validate(DUTCH_V2_CONFIG_JSON);
+      const { error } = FieldValidator.dutchV2Config.validate(DUTCH_V2_CONFIG_JSON);
       expect(error).toBeUndefined();
+    });
+
+    it('should reject dutch v2 config as dutch v1', () => {
+      const { error } = FieldValidator.dutchLimitConfig.validate(DUTCH_V2_CONFIG_JSON);
+      expect(error).toBeDefined();
+      expect(error?.message).toEqual('\"routingType\" must be [DUTCH_LIMIT]');
     });
 
     it('should reject invalid routingType', () => {
@@ -54,7 +60,7 @@ describe('Post quote request validation', () => {
         routingType: 'INVALID',
       });
       expect(error).toBeDefined();
-      expect(error?.message).toEqual('Invalid routingType');
+      expect(error?.message).toEqual('\"routingType\" must be [DUTCH_LIMIT]');
     });
 
     it('should reject invalid slippage', () => {
@@ -92,7 +98,7 @@ describe('Post quote request validation', () => {
         routingType: 'INVALID',
       });
       expect(error).toBeDefined();
-      expect(error?.message).toEqual('Invalid routingType');
+      expect(error?.message).toEqual('\"routingType\" must be [CLASSIC]');
     });
 
     it('should reject invalid protocols', () => {

--- a/test/unit/lib/handlers/quote/schema.test.ts
+++ b/test/unit/lib/handlers/quote/schema.test.ts
@@ -6,6 +6,7 @@ import {
   CHAIN_OUT_ID,
   CLASSIC_CONFIG,
   DL_CONFIG,
+  DUTCH_V2_CONFIG,
   TOKEN_IN,
   TOKEN_OUT,
 } from '../../../../constants';
@@ -13,6 +14,11 @@ import {
 const DL_CONFIG_JSON = {
   ...DL_CONFIG,
   routingType: 'DUTCH_LIMIT',
+};
+
+const DUTCH_V2_CONFIG_JSON = {
+  ...DUTCH_V2_CONFIG,
+  routingType: 'DUTCH_V2',
 };
 
 const CLASSIC_CONFIG_JSON = {
@@ -34,6 +40,11 @@ describe('Post quote request validation', () => {
   describe('config validation', () => {
     it('should validate dutch limit config', () => {
       const { error } = FieldValidator.dutchLimitConfig.validate(DL_CONFIG_JSON);
+      expect(error).toBeUndefined();
+    });
+
+    it('should validate dutch v2 config', () => {
+      const { error } = FieldValidator.dutchLimitConfig.validate(DUTCH_V2_CONFIG_JSON);
       expect(error).toBeUndefined();
     });
 


### PR DESCRIPTION
and enforce every config has the proper routing type. Currently it would accept a dutch config with dutch_v2 routing type, a dutch config with classic routing type etc. Now each type is pegged to the routing type