### PR TITLE
chore(deploy): Set env variable on beta lambda to reload secrets

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -147,7 +147,7 @@ export class APIPipeline extends Stack {
       envVars: {
         ...envVars,
         ...jsonRpcProviders,
-        VERSION: '1',
+        RELOAD: '1',
         ROUTING_API_KEY: routingApiKeySecret.secretValue.toString(),
         PARAMETERIZATION_API_KEY: parameterizationApiKeySecret.secretValue.toString(),
         PARAMETERIZATION_API_URL: urlSecrets.secretValueFromJson('PARAMETERIZATION_API_BETA').toString(),

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -147,6 +147,7 @@ export class APIPipeline extends Stack {
       envVars: {
         ...envVars,
         ...jsonRpcProviders,
+        VERSION: '1',
         ROUTING_API_KEY: routingApiKeySecret.secretValue.toString(),
         PARAMETERIZATION_API_KEY: parameterizationApiKeySecret.secretValue.toString(),
         PARAMETERIZATION_API_URL: urlSecrets.secretValueFromJson('PARAMETERIZATION_API_BETA').toString(),


### PR DESCRIPTION
We need to set a dummy env variable to force the beta secrets to reload
