### PR TITLE
fix: bump ur-sdk to include UR deployed address on blast, and bump up lambda version to pick up the updated blast RPC URL from secret

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -230,7 +230,7 @@ export class APIStack extends cdk.Stack {
         sourceMap: true,
       },
       environment: {
-        VERSION: '9',
+        VERSION: '10',
         NODE_OPTIONS: '--enable-source-maps',
         stage: props.stage,
         ...props.envVars,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@uniswap/sdk-core": "^4.2.0",
     "@uniswap/smart-order-router": "3.25.0",
     "@uniswap/uniswapx-sdk": "1.5.0-alpha.7",
-    "@uniswap/universal-router-sdk": "1.7.1",
+    "@uniswap/universal-router-sdk": "1.8.2",
     "aws-cdk-lib": "2.85.0",
     "aws-embedded-metrics": "^4.1.0",
     "axios": "^1.2.1",

--- a/test/integ/quote-classic.test.ts
+++ b/test/integ/quote-classic.test.ts
@@ -11,6 +11,7 @@ import {
   NATIVE_CURRENCY,
   parseAmount,
   SWAP_ROUTER_02_ADDRESSES,
+  USDB_BLAST,
   USDC_MAINNET,
   USDT_MAINNET,
 } from '@uniswap/smart-order-router';
@@ -2496,7 +2497,7 @@ describe('quote', function () {
     [ChainId.ZORA]: null,
     [ChainId.ZORA_SEPOLIA]: null,
     [ChainId.ROOTSTOCK]: null,
-    [ChainId.BLAST]: null,
+    [ChainId.BLAST]: USDB_BLAST,
   };
 
   const TEST_ERC20_2: { [chainId in ChainId]: Token | null } = {
@@ -2522,7 +2523,7 @@ describe('quote', function () {
     [ChainId.ZORA]: null,
     [ChainId.ZORA_SEPOLIA]: null,
     [ChainId.ROOTSTOCK]: null,
-    [ChainId.BLAST]: null,
+    [ChainId.BLAST]: WNATIVE_ON(ChainId.BLAST),
   };
 
   // TODO: Find valid pools/tokens on optimistic kovan and polygon mumbai. We skip those tests for now.
@@ -2542,8 +2543,7 @@ describe('quote', function () {
       // We will follow up supporting ZORA and ROOTSTOCK
       c !== ChainId.ZORA &&
       c !== ChainId.ZORA_SEPOLIA &&
-      c !== ChainId.ROOTSTOCK &&
-      c !== ChainId.BLAST
+      c !== ChainId.ROOTSTOCK
   )) {
     for (const type of ['EXACT_INPUT', 'EXACT_OUTPUT']) {
       const erc1 = TEST_ERC20_1[chain];
@@ -2558,13 +2558,16 @@ describe('quote', function () {
         const wrappedNative = WNATIVE_ON(chain);
 
         it(`${wrappedNative.symbol} -> erc20`, async () => {
+          // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
+          const amount = type === 'EXACT_OUTPUT' && chain === ChainId.BLAST ? '0.002' : '1';
+
           const quoteReq: QuoteRequestBodyJSON = {
             requestId: 'id',
             tokenIn: wrappedNative.address,
             tokenInChainId: chain,
             tokenOut: erc1.address,
             tokenOutChainId: chain,
-            amount: await getAmountFromToken(type, wrappedNative, erc1, '1'),
+            amount: await getAmountFromToken(type, wrappedNative, erc1, amount),
             type,
             configs: [
               {
@@ -2573,6 +2576,10 @@ describe('quote', function () {
                 enableUniversalRouter: true,
               },
             ],
+            // actual classic-only quote doesn't pass in swapper,
+            // but we need it to ensure it can hit
+            // https://github.com/Uniswap/unified-routing-api/blob/78f72f971601a5c2b53b34d3c50222e06c0b8cf2/lib/entities/context/ClassicQuoteContext.ts#L34
+            swapper: alice.address,
           };
 
           try {
@@ -2586,13 +2593,16 @@ describe('quote', function () {
         });
 
         it(`erc20 -> erc20`, async () => {
+          // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
+          const amount = type === 'EXACT_OUTPUT' && chain === ChainId.BLAST ? '0.002' : '1';
+
           const quoteReq: QuoteRequestBodyJSON = {
             requestId: 'id',
             tokenIn: erc1.address,
             tokenInChainId: chain,
             tokenOut: erc2.address,
             tokenOutChainId: chain,
-            amount: await getAmountFromToken(type, erc1, erc2, '1'),
+            amount: await getAmountFromToken(type, erc1, erc2, amount),
             type,
             configs: [
               {
@@ -2600,6 +2610,10 @@ describe('quote', function () {
                 protocols: ['V2', 'V3', 'MIXED'],
               },
             ],
+            // actual classic-only quote doesn't pass in swapper,
+            // but we need it to ensure it can hit
+            // https://github.com/Uniswap/unified-routing-api/blob/78f72f971601a5c2b53b34d3c50222e06c0b8cf2/lib/entities/context/ClassicQuoteContext.ts#L34
+            swapper: alice.address,
           };
 
           try {
@@ -2613,6 +2627,11 @@ describe('quote', function () {
         });
         const native = NATIVE_CURRENCY[chain];
         it(`${native} -> erc20`, async () => {
+          if (chain === ChainId.BLAST) {
+            // Blast doesn't have DAI or USDC yet
+            return;
+          }
+
           const quoteReq: QuoteRequestBodyJSON = {
             requestId: 'id',
             tokenIn: native,
@@ -2640,13 +2659,16 @@ describe('quote', function () {
           }
         });
         it(`has quoteGasAdjusted values`, async () => {
+          // Current WETH/USDB pool (https://blastscan.io/address/0xf52b4b69123cbcf07798ae8265642793b2e8990c) has low WETH amount
+          const amount = type === 'EXACT_OUTPUT' && chain === ChainId.BLAST ? '0.002' : '1';
+
           const quoteReq: QuoteRequestBodyJSON = {
             requestId: 'id',
             tokenIn: erc1.address,
             tokenInChainId: chain,
             tokenOut: erc2.address,
             tokenOutChainId: chain,
-            amount: await getAmountFromToken(type, erc1, erc2, '1'),
+            amount: await getAmountFromToken(type, erc1, erc2, amount),
             type,
             configs: [
               {
@@ -2654,6 +2676,10 @@ describe('quote', function () {
                 protocols: ['V2', 'V3', 'MIXED'],
               },
             ],
+            // actual classic-only quote doesn't pass in swapper,
+            // but we need it to ensure it can hit
+            // https://github.com/Uniswap/unified-routing-api/blob/78f72f971601a5c2b53b34d3c50222e06c0b8cf2/lib/entities/context/ClassicQuoteContext.ts#L34
+            swapper: alice.address,
           };
 
           try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,17 +1964,6 @@
     "@uniswap/v2-sdk" "^3.0.1"
     "@uniswap/v3-sdk" "^3.8.3"
 
-"@uniswap/router-sdk@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/router-sdk/-/router-sdk-1.8.0.tgz#725419196ac8aebd5cca58026a1527d494f182a8"
-  integrity sha512-w9OY3r060eMJsoMYoKEx+Uzds/PRnQvzXf4G1EC2Z993J8/qlnbpOLM389TMbhDbaz+XSB9qvvPh4tf4H8QD/w==
-  dependencies:
-    "@ethersproject/abi" "^5.5.0"
-    "@uniswap/sdk-core" "^4.0.7"
-    "@uniswap/swap-router-contracts" "^1.1.0"
-    "@uniswap/v2-sdk" "^4.1.0"
-    "@uniswap/v3-sdk" "^3.10.1"
-
 "@uniswap/router-sdk@^1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@uniswap/router-sdk/-/router-sdk-1.9.0.tgz#f35432ddc400ddb83985adc840c5898e2bc008cd"
@@ -2002,18 +1991,6 @@
   version "4.0.6"
   resolved "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-4.0.6.tgz"
   integrity sha512-6GzCVfnOiJtvo91zlF/VjnC2OEbBRThVclzrh7+Zmo8dBovXwSlXwqn3RkSWACn/XEOzAKH70TficfOWm6mWJA==
-  dependencies:
-    "@ethersproject/address" "^5.0.2"
-    big.js "^5.2.2"
-    decimal.js-light "^2.5.0"
-    jsbi "^3.1.4"
-    tiny-invariant "^1.1.0"
-    toformat "^2.0.0"
-
-"@uniswap/sdk-core@^4.0.7":
-  version "4.0.7"
-  resolved "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-4.0.7.tgz"
-  integrity sha512-jscx7KUIWzQatcL5PHY6xy0gEL9IGQcL5h/obxzX9foP2KoNk9cq66Ia8I2Kvpa7zBcPOeW1hU0hJNBq6CzcIQ==
   dependencies:
     "@ethersproject/address" "^5.0.2"
     big.js "^5.2.2"
@@ -2115,17 +2092,17 @@
     "@uniswap/sdk-core" "^4.0.3"
     ethers "^5.7.0"
 
-"@uniswap/universal-router-sdk@1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.7.1.tgz#1519fc898f430ced500b65781eb8bc13f59804c7"
-  integrity sha512-No8E/02Y9DiWD7E3XOHY0pcqh+zc6ZU5JLgx9Pw/0Nc5DA4Pa2fs8C+gQ1tnNt3YSoPrRxFNLPE9CE2gUgz6Eg==
+"@uniswap/universal-router-sdk@1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.8.2.tgz#ce9b7553e178f091846ca541870235ef8f2a465d"
+  integrity sha512-u7ZnKxf4NH2J3DoTOOueh2rNruQku1JpLTRGl+/Kvol1NKTXdMAkaTTNRcwBzSpolpfbldK4pAIuwDza7gWzDw==
   dependencies:
     "@uniswap/permit2-sdk" "^1.2.0"
-    "@uniswap/router-sdk" "^1.8.0"
-    "@uniswap/sdk-core" "^4.0.7"
+    "@uniswap/router-sdk" "^1.9.0"
+    "@uniswap/sdk-core" "^4.2.0"
     "@uniswap/universal-router" "1.6.0"
-    "@uniswap/v2-sdk" "^4.1.0"
-    "@uniswap/v3-sdk" "^3.10.1"
+    "@uniswap/v2-sdk" "^4.2.0"
+    "@uniswap/v3-sdk" "^3.11.0"
     bignumber.js "^9.0.2"
     ethers "^5.3.1"
 
@@ -2165,17 +2142,6 @@
     "@ethersproject/address" "^5.0.0"
     "@ethersproject/solidity" "^5.0.0"
     "@uniswap/sdk-core" "^3.0.0-alpha.3"
-    tiny-invariant "^1.1.0"
-    tiny-warning "^1.0.3"
-
-"@uniswap/v2-sdk@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/v2-sdk/-/v2-sdk-4.1.0.tgz#05c18bcef11daeec3224e0fb78e81eeb4e0d31d0"
-  integrity sha512-sIfEF/zYxssjXNum1HBO/vT5rQuDuSuKB3rp23z1V9vZaatkWwW91LwJtlpVh5X0j+nZ+nduBb1pWxeDHdq4Zg==
-  dependencies:
-    "@ethersproject/address" "^5.0.0"
-    "@ethersproject/solidity" "^5.0.0"
-    "@uniswap/sdk-core" "^4.0.7"
     tiny-invariant "^1.1.0"
     tiny-warning "^1.0.3"
 
@@ -2245,20 +2211,6 @@
     "@uniswap/v2-core" "^1.0.1"
     "@uniswap/v3-core" "^1.0.0"
     base64-sol "1.0.1"
-
-"@uniswap/v3-sdk@^3.10.1":
-  version "3.10.2"
-  resolved "https://registry.yarnpkg.com/@uniswap/v3-sdk/-/v3-sdk-3.10.2.tgz#dd23aa80b9b3a539ecdd5532e6778cd2aa799e31"
-  integrity sha512-5sfYSvRB9ityrB0c/MFaYUsTBQvrwgCuXSyBPsqU8fh6v2dzFgOD3SLx/tHFg8R0RRyN4XPTrw6nqDYXRFtu+g==
-  dependencies:
-    "@ethersproject/abi" "^5.0.12"
-    "@ethersproject/solidity" "^5.0.9"
-    "@uniswap/sdk-core" "^4.0.7"
-    "@uniswap/swap-router-contracts" "^1.2.1"
-    "@uniswap/v3-periphery" "^1.1.1"
-    "@uniswap/v3-staker" "1.0.0"
-    tiny-invariant "^1.1.0"
-    tiny-warning "^1.0.3"
 
 "@uniswap/v3-sdk@^3.11.0":
   version "3.11.0"


### PR DESCRIPTION
If I don't pass in swapper in the classic quote request, I can get the quote back on blast: https://app.warp.dev/block/mENVV16CvXLSF8M6Pgascw. If I do pass in swapper, then I will get runtime error https://app.warp.dev/block/vkMMYMGTIV7DvCJH0fKZny. The reason is because by passing in swapper, URA will try to fetch [permit](https://github.com/Uniswap/unified-routing-api/blob/78f72f971601a5c2b53b34d3c50222e06c0b8cf2/lib/entities/context/ClassicQuoteContext.ts#L34) for the swapper. But ur-sdk 1.7.1 doesn't contain the [UNIVERSAL_ROUTER_ADDRESS](https://github.com/Uniswap/unified-routing-api/blob/78f72f971601a5c2b53b34d3c50222e06c0b8cf2/lib/entities/context/ClassicQuoteContext.ts#L39C9-L39C33) on blast yet. So the fix is to upgrade ur-sdk to 1.8.2 which contains the correct UR address on blast.

We also have to bump the lambda version in this PR, because we updated the blast RPC URL in our secret.

In order to ensure the blast quote can work at the URA level, meanwhile passing in swapper, blast integ-test has been added. They can pass on my local https://app.warp.dev/block/LyxjePqAddGTainjTKyZTI.