### PR TITLE
fix: remove xv2 integ tests for hard quote

### DIFF
--- a/test/integ/base.test.ts
+++ b/test/integ/base.test.ts
@@ -42,10 +42,6 @@ if (!process.env.UNISWAP_API || !process.env.ARCHIVE_NODE_RPC) {
   throw new Error('Must set UNISWAP_API and ARCHIVE_NODE_RPC env variables for integ tests. See README');
 }
 
-if (!process.env.PARAM_API_URL) {
-  throw new Error('Must set PARAM_API_URL env variables for integ tests. See README');
-}
-
 if (!process.env.PORTION_API_URL) {
   throw new Error('Must set PORTION_API_URL env variables for integ tests. See README');
 }
@@ -117,13 +113,6 @@ export const callIndicative = async (
   config = axiosConfig
 ): Promise<AxiosResponse<QuoteResponseJSON>> => {
   return await axiosHelper.post<QuoteResponseJSON>(`${API}`, quoteReq, config);
-};
-
-export const callHard = async (
-  hardQuoteReq: Partial<HardQuoteRequest>,
-  config = axiosConfig
-): Promise<AxiosResponse<HardQuoteResponseData>> => {
-  return await axiosHelper.post<HardQuoteResponseData>(`${hardQuoteAPI}`, hardQuoteReq, config);
 };
 
 export const checkQuoteToken = (

--- a/test/integ/base.test.ts
+++ b/test/integ/base.test.ts
@@ -42,12 +42,16 @@ if (!process.env.UNISWAP_API || !process.env.ARCHIVE_NODE_RPC) {
   throw new Error('Must set UNISWAP_API and ARCHIVE_NODE_RPC env variables for integ tests. See README');
 }
 
-if (!process.env.URA_INTERNAL_API_KEY) {
-  console.log('URA_INTERNAL_API_KEY env variable is not set. This is recommended for integ tests.');
+if (!process.env.PARAM_API_URL) {
+  throw new Error('Must set PARAM_API_URL env variables for integ tests. See README');
 }
 
 if (!process.env.PORTION_API_URL) {
   throw new Error('Must set PORTION_API_URL env variables for integ tests. See README');
+}
+
+if (!process.env.URA_INTERNAL_API_KEY) {
+  console.log('URA_INTERNAL_API_KEY env variable is not set. This is recommended for integ tests.');
 }
 
 // URA endpoint

--- a/test/integ/base.test.ts
+++ b/test/integ/base.test.ts
@@ -52,7 +52,6 @@ if (!process.env.URA_INTERNAL_API_KEY) {
 
 // URA endpoint
 const API = `${process.env.UNISWAP_API!}quote`;
-const hardQuoteAPI = `${process.env.PARAM_API_URL!}hard-quote`;
 
 const SLIPPAGE = '5';
 

--- a/test/integ/quote-xv2.test.ts
+++ b/test/integ/quote-xv2.test.ts
@@ -48,7 +48,7 @@ describe('quoteUniswapX-v2', function () {
             {
               routingType: RoutingType.DUTCH_V2,
               swapper: alice.address,
-              useSyntheticQuotes: false,
+              useSyntheticQuotes: true,
             },
           ] as RoutingConfigJSON[],
         };

--- a/test/integ/quote-xv2.test.ts
+++ b/test/integ/quote-xv2.test.ts
@@ -10,13 +10,12 @@ import { RoutingType } from '../../lib/constants';
 import { QuoteRequestBodyJSON, RoutingConfigJSON } from '../../lib/entities';
 import { QuoteResponseJSON } from '../../lib/handlers/quote/handler';
 import { getAmount } from '../utils/tokens';
-import { BaseIntegrationTestSuite, callHard, callIndicative, HardQuoteResponseData } from './base.test';
+import { BaseIntegrationTestSuite, callIndicative } from './base.test';
 
 chai.use(chaiAsPromised);
 chai.use(chaiSubset);
 
 const SLIPPAGE = '5';
-const REQUEST_ID = 'bbe75c5f-8ae5-46a1-ab3d-ce201cf56689';
 
 describe('quoteUniswapX-v2', function () {
   let baseTest: BaseIntegrationTestSuite;
@@ -69,65 +68,6 @@ describe('quoteUniswapX-v2', function () {
         } catch (e: any) {
           expect(e.response.status).to.equal(404);
           expect(e.response.data.detail).to.equal('No quotes available');
-        }
-      });
-
-      // TODO: maybe move this to param-api integ tests?
-      it('stable -> stable, large trade', async () => {
-        const quoteReq: QuoteRequestBodyJSON = {
-          requestId: 'id',
-          useUniswapX: true,
-          tokenIn: USDC_MAINNET.address,
-          tokenInChainId: 1,
-          tokenOut: USDT_MAINNET.address,
-          tokenOutChainId: 1,
-          amount: await getAmount(1, type, 'USDC', 'USDT', '10000'),
-          type,
-          slippageTolerance: SLIPPAGE,
-          configs: [
-            {
-              routingType: RoutingType.DUTCH_V2,
-              swapper: alice.address,
-              useSyntheticQuotes: true,
-            },
-          ] as RoutingConfigJSON[],
-        };
-
-        const response: AxiosResponse<QuoteResponseJSON> = await callIndicative(quoteReq);
-        const {
-          data: { quote },
-          status,
-        } = response;
-
-        const order = new UnsignedV2DutchOrder((quote as any).orderInfo, 1);
-        expect(status).to.equal(200);
-
-        expect(order.info.swapper).to.equal(alice.address);
-        expect(order.info.outputs.length).to.equal(1);
-        expect(parseInt(order.info.outputs[0].startAmount.toString())).to.be.greaterThan(9000000000);
-        expect(parseInt(order.info.outputs[0].startAmount.toString())).to.be.lessThan(11000000000);
-        expect(parseInt(order.info.input.startAmount.toString())).to.be.greaterThan(9000000000);
-        expect(parseInt(order.info.input.startAmount.toString())).to.be.lessThan(11000000000);
-
-        // user accepts and signs quote
-        const { domain, types, values } = order.permitData();
-        const signature = await alice._signTypedData(domain, types, values);
-        const encodedInnerOrder = order.serialize();
-        const hardQuoteReq = {
-          requestId: REQUEST_ID,
-          encodedInnerOrder,
-          innerSig: signature,
-          tokenInChainId: 1,
-          tokenOutChainId: 1,
-        };
-        //TODO: other infras are in place we can remove the try catch
-        try {
-          const secondaryResponse: AxiosResponse<HardQuoteResponseData> = await callHard(hardQuoteReq);
-          expect(secondaryResponse.status).to.equal(200);
-        } catch (e: any) {
-          expect(['Unknown cosigner', 'Error posting order', 'No quotes available', 'Error posting order']).to.include(
-            e.response.data.detail
-          );
         }
       });
     });

--- a/test/integ/quote-xv2.test.ts
+++ b/test/integ/quote-xv2.test.ts
@@ -62,9 +62,15 @@ describe('quoteUniswapX-v2', function () {
 
           const order = new UnsignedV2DutchOrder((quote as any).orderInfo, 1);
           expect(status).to.equal(200);
-          expect(order.info.cosigner).to.equal(ethers.constants.AddressZero);
+  
           expect(order.info.swapper).to.equal(alice.address);
+          // No cosigner set
+          expect(order.info.cosigner).to.equal(ethers.constants.AddressZero);
           expect(order.info.outputs.length).to.equal(1);
+          expect(parseInt(order.info.outputs[0].startAmount.toString())).to.be.greaterThan(9000000000);
+          expect(parseInt(order.info.outputs[0].startAmount.toString())).to.be.lessThan(11000000000);
+          expect(parseInt(order.info.input.startAmount.toString())).to.be.greaterThan(9000000000);
+          expect(parseInt(order.info.input.startAmount.toString())).to.be.lessThan(11000000000);
         } catch (e: any) {
           expect(e.response.status).to.equal(404);
           expect(e.response.data.detail).to.equal('No quotes available');


### PR DESCRIPTION
We've moved hard quote tests into GPA so we can remove it here