### PR TITLE
fix: bump x sdk to latest alpha.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@uniswap/router-sdk": "^1.9.0",
     "@uniswap/sdk-core": "^4.2.0",
     "@uniswap/smart-order-router": "^3.26.0",
-    "@uniswap/uniswapx-sdk": "^2.0.1-alpha.4",
+    "@uniswap/uniswapx-sdk": "^2.0.1-alpha.10",
     "@uniswap/universal-router-sdk": "^1.9.0",
     "aws-cdk-lib": "2.85.0",
     "aws-embedded-metrics": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,10 +2165,10 @@
   resolved "https://registry.npmjs.org/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz"
   integrity sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg==
 
-"@uniswap/uniswapx-sdk@^2.0.1-alpha.4":
-  version "2.0.1-alpha.4"
-  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-2.0.1-alpha.4.tgz#812d7fe33a43497a82f4921a278a9ba4e2cd4b16"
-  integrity sha512-T1wbfNSMbPm5V94Hi29i5sVOwkqWOdz9x20e+MuYvYMluUhx7NHCpDf0JltPv3Vpi26eR8gwIJyu9ublU0BsQA==
+"@uniswap/uniswapx-sdk@^2.0.1-alpha.10":
+  version "2.0.1-alpha.10"
+  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-2.0.1-alpha.10.tgz#7ea770031fd59bb92121ad6c44c1a8710055b995"
+  integrity sha512-nDWJ9qLFBLId2lxJ8TMy15HIBlzQe2yFE6LEJSzEF1T5EGDFv1G/ioKQSm2LJg4cO11UfVouHKsn6rwYS6P9wA==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/providers" "^5.7.0"


### PR DESCRIPTION
There was a breaking change to the uniswapx-sdk which changed input and outputs in DutchV2 orders to baseInput and baseOutputs. We have decided to revert all changes back to `input` and `outputs` for the short term to fix downstream errors in other services until we determine a path forward.