### PR TITLE
feat: Forward headers to RoutingAPI

### DIFF
--- a/lib/entities/request/ClassicRequest.ts
+++ b/lib/entities/request/ClassicRequest.ts
@@ -1,8 +1,7 @@
 import { Protocol } from '@uniswap/router-sdk';
-import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
 import { BigNumber } from 'ethers';
 
-import { defaultRequestKey, QuoteRequest, QuoteRequestInfo } from '.';
+import { defaultRequestKey, QuoteRequest, QuoteRequestHeaders, QuoteRequestInfo } from '.';
 import { RoutingType } from '../../constants';
 import { DutchRequest } from './DutchRequest';
 
@@ -63,7 +62,7 @@ export class ClassicRequest implements QuoteRequest {
   constructor(
     public readonly info: QuoteRequestInfo,
     public readonly config: ClassicConfig,
-    public headers: APIGatewayProxyEventHeaders = {}
+    public headers: QuoteRequestHeaders = {}
   ) {}
 
   public toJSON(): ClassicConfigJSON {

--- a/lib/entities/request/ClassicRequest.ts
+++ b/lib/entities/request/ClassicRequest.ts
@@ -1,4 +1,5 @@
 import { Protocol } from '@uniswap/router-sdk';
+import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
 import { BigNumber } from 'ethers';
 
 import { defaultRequestKey, QuoteRequest, QuoteRequestInfo } from '.';
@@ -59,7 +60,11 @@ export class ClassicRequest implements QuoteRequest {
     });
   }
 
-  constructor(public readonly info: QuoteRequestInfo, public readonly config: ClassicConfig) {}
+  constructor(
+    public readonly info: QuoteRequestInfo,
+    public readonly config: ClassicConfig,
+    public headers: APIGatewayProxyEventHeaders = {}
+  ) {}
 
   public toJSON(): ClassicConfigJSON {
     return Object.assign({}, this.config, {

--- a/lib/entities/request/DutchRequest.ts
+++ b/lib/entities/request/DutchRequest.ts
@@ -1,10 +1,9 @@
-import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
-import { defaultRequestKey, QuoteRequest, QuoteRequestInfo } from '.';
+import { defaultRequestKey, QuoteRequest, QuoteRequestHeaders, QuoteRequestInfo } from '.';
 import {
   DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
   DEFAULT_SLIPPAGE_TOLERANCE,
   NATIVE_ADDRESS,
-  RoutingType,
+  RoutingType
 } from '../../constants';
 
 export * from './ClassicRequest';
@@ -57,7 +56,7 @@ export class DutchRequest implements QuoteRequest {
   constructor(
     public readonly info: DutchQuoteRequestInfo,
     public readonly config: DutchConfig,
-    public headers: APIGatewayProxyEventHeaders = {}
+    public headers: QuoteRequestHeaders = {}
   ) {}
 
   public toJSON(): DutchConfigJSON {

--- a/lib/entities/request/DutchRequest.ts
+++ b/lib/entities/request/DutchRequest.ts
@@ -1,3 +1,4 @@
+import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
 import { defaultRequestKey, QuoteRequest, QuoteRequestInfo } from '.';
 import {
   DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
@@ -53,7 +54,11 @@ export class DutchRequest implements QuoteRequest {
     );
   }
 
-  constructor(public readonly info: DutchQuoteRequestInfo, public readonly config: DutchConfig) {}
+  constructor(
+    public readonly info: DutchQuoteRequestInfo,
+    public readonly config: DutchConfig,
+    public headers: APIGatewayProxyEventHeaders = {}
+  ) {}
 
   public toJSON(): DutchConfigJSON {
     return Object.assign({}, this.config, {

--- a/lib/entities/request/DutchV2Request.ts
+++ b/lib/entities/request/DutchV2Request.ts
@@ -1,6 +1,5 @@
-import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
 import { ethers } from 'ethers';
-import { defaultRequestKey, QuoteRequest, QuoteRequestInfo } from '.';
+import { defaultRequestKey, QuoteRequest, QuoteRequestHeaders, QuoteRequestInfo } from '.';
 import { DEFAULT_SLIPPAGE_TOLERANCE, RoutingType } from '../../constants';
 import { DutchQuoteRequestInfo, DutchRequest as DutchV1Request } from './DutchRequest';
 
@@ -36,7 +35,7 @@ export class DutchV2Request implements QuoteRequest {
   constructor(
     public readonly info: DutchQuoteRequestInfo,
     public readonly config: DutchV2Config,
-    public headers: APIGatewayProxyEventHeaders = {}
+    public headers: QuoteRequestHeaders = {}
   ) {}
 
   public toDutchV1Request(): DutchV1Request {

--- a/lib/entities/request/DutchV2Request.ts
+++ b/lib/entities/request/DutchV2Request.ts
@@ -1,3 +1,4 @@
+import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
 import { ethers } from 'ethers';
 import { defaultRequestKey, QuoteRequest, QuoteRequestInfo } from '.';
 import { DEFAULT_SLIPPAGE_TOLERANCE, RoutingType } from '../../constants';
@@ -32,7 +33,11 @@ export class DutchV2Request implements QuoteRequest {
     );
   }
 
-  constructor(public readonly info: DutchQuoteRequestInfo, public readonly config: DutchV2Config) {}
+  constructor(
+    public readonly info: DutchQuoteRequestInfo,
+    public readonly config: DutchV2Config,
+    public headers: APIGatewayProxyEventHeaders = {}
+  ) {}
 
   public toDutchV1Request(): DutchV1Request {
     return new DutchV1Request(this.info, {

--- a/lib/entities/request/RelayRequest.ts
+++ b/lib/entities/request/RelayRequest.ts
@@ -1,4 +1,5 @@
 import { Protocol } from '@uniswap/router-sdk';
+import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
 
 import { BigNumber } from 'ethers';
 import { ClassicConfig, ClassicConfigJSON, defaultRequestKey, parseProtocol, QuoteRequest, QuoteRequestInfo } from '.';
@@ -53,7 +54,11 @@ export class RelayRequest implements QuoteRequest {
     );
   }
 
-  constructor(public readonly info: RelayQuoteRequestInfo, public readonly config: RelayConfig) {}
+  constructor(
+    public readonly info: RelayQuoteRequestInfo,
+    public readonly config: RelayConfig,
+    public headers: APIGatewayProxyEventHeaders = {}
+  ) {}
 
   public toJSON(): RelayConfigJSON {
     return Object.assign({}, this.config, {

--- a/lib/entities/request/RelayRequest.ts
+++ b/lib/entities/request/RelayRequest.ts
@@ -1,8 +1,15 @@
 import { Protocol } from '@uniswap/router-sdk';
-import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
 
 import { BigNumber } from 'ethers';
-import { ClassicConfig, ClassicConfigJSON, defaultRequestKey, parseProtocol, QuoteRequest, QuoteRequestInfo } from '.';
+import {
+  ClassicConfig,
+  ClassicConfigJSON,
+  defaultRequestKey,
+  parseProtocol,
+  QuoteRequest,
+  QuoteRequestHeaders,
+  QuoteRequestInfo
+} from '.';
 import { DEFAULT_SLIPPAGE_TOLERANCE, NATIVE_ADDRESS, RoutingType } from '../../constants';
 
 export * from './ClassicRequest';
@@ -57,7 +64,7 @@ export class RelayRequest implements QuoteRequest {
   constructor(
     public readonly info: RelayQuoteRequestInfo,
     public readonly config: RelayConfig,
-    public headers: APIGatewayProxyEventHeaders = {}
+    public headers: QuoteRequestHeaders = {}
   ) {}
 
   public toJSON(): RelayConfigJSON {

--- a/lib/entities/request/index.ts
+++ b/lib/entities/request/index.ts
@@ -1,6 +1,5 @@
 import { Protocol } from '@uniswap/router-sdk';
 import { TradeType } from '@uniswap/sdk-core';
-import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
 import { BigNumber } from 'ethers';
 
 import { SUPPORTED_CHAINS } from '../../config/chains';

--- a/lib/entities/request/index.ts
+++ b/lib/entities/request/index.ts
@@ -60,7 +60,7 @@ export interface QuoteRequest {
   routingType: RoutingType;
   info: QuoteRequestInfo;
   config: RoutingConfig;
-  headers?: APIGatewayProxyEventHeaders;
+  headers: APIGatewayProxyEventHeaders;
 
   toJSON(): RoutingConfigJSON;
   // return a key that uniquely identifies this request

--- a/lib/entities/request/index.ts
+++ b/lib/entities/request/index.ts
@@ -1,5 +1,6 @@
 import { Protocol } from '@uniswap/router-sdk';
 import { TradeType } from '@uniswap/sdk-core';
+import { APIGatewayProxyEventHeaders } from 'aws-lambda/trigger/api-gateway-proxy';
 import { BigNumber } from 'ethers';
 
 import { SUPPORTED_CHAINS } from '../../config/chains';
@@ -59,6 +60,7 @@ export interface QuoteRequest {
   routingType: RoutingType;
   info: QuoteRequestInfo;
   config: RoutingConfig;
+  headers?: APIGatewayProxyEventHeaders;
 
   toJSON(): RoutingConfigJSON;
   // return a key that uniquely identifies this request

--- a/lib/entities/request/index.ts
+++ b/lib/entities/request/index.ts
@@ -23,6 +23,10 @@ export type RequestByRoutingType = { [routingType in RoutingType]?: QuoteRequest
 export type RoutingConfig = DutchConfig | DutchV2Config | RelayConfig | ClassicConfig;
 export type RoutingConfigJSON = DutchConfigJSON | DutchV2ConfigJSON | RelayConfigJSON | ClassicConfigJSON;
 
+export interface QuoteRequestHeaders {
+  [name: string]: string | undefined;
+}
+
 // shared info for all quote requests
 export interface QuoteRequestInfo {
   requestId: string;
@@ -60,7 +64,7 @@ export interface QuoteRequest {
   routingType: RoutingType;
   info: QuoteRequestInfo;
   config: RoutingConfig;
-  headers: APIGatewayProxyEventHeaders;
+  headers: QuoteRequestHeaders;
 
   toJSON(): RoutingConfigJSON;
   // return a key that uniquely identifies this request

--- a/lib/handlers/quote/handler.ts
+++ b/lib/handlers/quote/handler.ts
@@ -132,6 +132,7 @@ export class QuoteHandler extends APIGLambdaHandler<
 
     for (const request of requests) {
       request.info.source = requestSource;
+      request.headers = params.event.headers;
     }
 
     const beforeGetQuotes = Date.now();

--- a/lib/providers/quoters/RoutingApiQuoter.ts
+++ b/lib/providers/quoters/RoutingApiQuoter.ts
@@ -23,7 +23,12 @@ export class RoutingApiQuoter implements Quoter {
     try {
       const req = this.buildRequest(request);
       const now = Date.now();
-      const response = await axios.get<ClassicQuoteDataJSON>(req, { headers: { 'x-api-key': this.routingApiKey } });
+      const response = await axios.get<ClassicQuoteDataJSON>(req, {
+        headers: {
+          ...request.headers,
+          'x-api-key': this.routingApiKey
+        }
+      });
       const portionAdjustedResponse: AxiosResponse<ClassicQuoteDataJSON> = {
         ...response,
         // NOTE: important to show portion-related fields under flag on only

--- a/test/unit/providers/quoters/RoutingApiQuoter.test.ts
+++ b/test/unit/providers/quoters/RoutingApiQuoter.test.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import NodeCache from 'node-cache';
 import { ClassicQuote } from '../../../../lib/entities';
-import { GetPortionResponse, GET_NO_PORTION_RESPONSE, PortionFetcher } from '../../../../lib/fetchers/PortionFetcher';
+import { GET_NO_PORTION_RESPONSE, GetPortionResponse, PortionFetcher } from '../../../../lib/fetchers/PortionFetcher';
 import { RoutingApiQuoter } from '../../../../lib/providers/quoters';
 import axios from '../../../../lib/providers/quoters/helpers';
 import { PORTION_BIPS, PORTION_RECIPIENT } from '../../../constants';
@@ -9,9 +9,10 @@ import {
   CLASSIC_QUOTE_DATA,
   CLASSIC_QUOTE_DATA_WITH_FOX_TAX,
   CLASSIC_QUOTE_DATA_WITH_PORTION,
+  makeClassicRequest,
   QUOTE_REQUEST_CLASSIC,
   QUOTE_REQUEST_CLASSIC_FE_ENABLE_FEE_ON_TRANSFER,
-  QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION,
+  QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION
 } from '../../../utils/fixtures';
 
 describe('RoutingApiQuoter', () => {
@@ -164,6 +165,20 @@ describe('RoutingApiQuoter', () => {
       // By strictly asserting the route equals the test setup route, which includes BULLET_WITH_TAX in both token out and pool reserve0,
       // we effectively assert that RoutingApiQuoter.quote now returns the FOT tax in the response payload
       expect(classicQuote.toJSON().route).toStrictEqual(CLASSIC_QUOTE_DATA_WITH_FOX_TAX.quote.route);
+    });
+
+    it('quote with headers', async () => {
+      const request =  makeClassicRequest({});
+      request.headers = {'x-request-source': 'uniswap-ios'};
+      axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
+      const response = await routingApiQuoter.quote(request);
+      expect(response).toBeDefined();
+      expect(response).toBeInstanceOf(ClassicQuote);
+
+      expect(axiosMock).toHaveBeenCalledWith(
+        expect.any(String),
+        { headers: expect.objectContaining({'x-request-source': 'uniswap-ios'})}
+      )
     });
   });
 


### PR DESCRIPTION
# Forward Headers from URA to RoutingApi

This PR adds a way to forward all headers coming from the URA to the RoutingAPI call. These headers will contain the x-request-source and x-app-version that we care about.
