### PR TITLE
fix: Only forward request-source and app version headers

### DIFF
--- a/lib/providers/quoters/RoutingApiQuoter.ts
+++ b/lib/providers/quoters/RoutingApiQuoter.ts
@@ -4,7 +4,7 @@ import { AxiosError, AxiosResponse } from 'axios';
 import querystring from 'querystring';
 
 import { frontendAndUraEnablePortion, NATIVE_ADDRESS, RoutingType } from '../../constants';
-import { ClassicQuote, ClassicQuoteDataJSON, ClassicRequest, Quote } from '../../entities';
+import { ClassicQuote, ClassicQuoteDataJSON, ClassicRequest, Quote, QuoteRequestHeaders } from '../../entities';
 import { metrics } from '../../util/metrics';
 import axios from './helpers';
 import { Quoter, QuoterType } from './index';
@@ -23,11 +23,12 @@ export class RoutingApiQuoter implements Quoter {
     try {
       const req = this.buildRequest(request);
       const now = Date.now();
+      const requestHeaders: QuoteRequestHeaders = {'x-api-key': this.routingApiKey};
+      if (request.headers['x-request-source']) requestHeaders['x-request-source'] = request.headers['x-request-source'];
+      if (request.headers['x-app-version']) requestHeaders['x-app-version'] = request.headers['x-app-version'];
+
       const response = await axios.get<ClassicQuoteDataJSON>(req, {
-        headers: {
-          ...request.headers,
-          'x-api-key': this.routingApiKey
-        }
+        headers: requestHeaders
       });
       const portionAdjustedResponse: AxiosResponse<ClassicQuoteDataJSON> = {
         ...response,

--- a/test/unit/providers/quoters/RoutingApiQuoter.test.ts
+++ b/test/unit/providers/quoters/RoutingApiQuoter.test.ts
@@ -167,7 +167,7 @@ describe('RoutingApiQuoter', () => {
       expect(classicQuote.toJSON().route).toStrictEqual(CLASSIC_QUOTE_DATA_WITH_FOX_TAX.quote.route);
     });
 
-    it('quote with headers', async () => {
+    it('quote with x-request-source headers', async () => {
       const request =  makeClassicRequest({});
       request.headers = {'x-request-source': 'uniswap-ios'};
       axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
@@ -178,6 +178,34 @@ describe('RoutingApiQuoter', () => {
       expect(axiosMock).toHaveBeenCalledWith(
         expect.any(String),
         { headers: expect.objectContaining({'x-request-source': 'uniswap-ios'})}
+      )
+    });
+
+    it('quote with x-request-source and x-app-version headers', async () => {
+      const request =  makeClassicRequest({});
+      request.headers = {'x-request-source': 'uniswap-ios', 'x-app-version': '1.27'};
+      axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
+      const response = await routingApiQuoter.quote(request);
+      expect(response).toBeDefined();
+      expect(response).toBeInstanceOf(ClassicQuote);
+
+      expect(axiosMock).toHaveBeenCalledWith(
+        expect.any(String),
+        { headers: expect.objectContaining({'x-request-source': 'uniswap-ios', 'x-app-version': '1.27'})}
+      )
+    });
+
+    it('quote with x-request-source, x-app-version and aws-timestamp headers, ignores aws header', async () => {
+      const request =  makeClassicRequest({});
+      request.headers = {'x-request-source': 'uniswap-ios', 'x-app-version': '1.27', 'aws-timestamp': '12345678'};
+      axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
+      const response = await routingApiQuoter.quote(request);
+      expect(response).toBeDefined();
+      expect(response).toBeInstanceOf(ClassicQuote);
+
+      expect(axiosMock).toHaveBeenCalledWith(
+        expect.any(String),
+        { headers: {'x-api-key': 'test-key', 'x-request-source': 'uniswap-ios', 'x-app-version': '1.27'}}
       )
     });
   });


### PR DESCRIPTION
AWS doesn't like to share headers, so we will manually pick the headers that we care about, in this case x-request-source and x-app-version
