### PR TITLE
fix: portion for synthetic dutch

### DIFF
--- a/lib/entities/quote/DutchQuote.ts
+++ b/lib/entities/quote/DutchQuote.ts
@@ -198,7 +198,7 @@ export class DutchQuote implements IQuote {
       quote.quoteType,
       quote.filler,
       quote.nonce,
-      classic.portion,
+      quote.portion === undefined ? classic.portion : quote.portion,
       {
         largeTrade: options?.largeTrade ?? false,
       }

--- a/lib/entities/request/DutchRequest.ts
+++ b/lib/entities/request/DutchRequest.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_EXCLUSIVITY_OVERRIDE_BPS,
   DEFAULT_SLIPPAGE_TOLERANCE,
   NATIVE_ADDRESS,
-  RoutingType
+  RoutingType,
 } from '../../constants';
 
 export * from './ClassicRequest';

--- a/lib/entities/request/RelayRequest.ts
+++ b/lib/entities/request/RelayRequest.ts
@@ -8,7 +8,7 @@ import {
   parseProtocol,
   QuoteRequest,
   QuoteRequestHeaders,
-  QuoteRequestInfo
+  QuoteRequestInfo,
 } from '.';
 import { DEFAULT_SLIPPAGE_TOLERANCE, NATIVE_ADDRESS, RoutingType } from '../../constants';
 

--- a/lib/providers/quoters/RoutingApiQuoter.ts
+++ b/lib/providers/quoters/RoutingApiQuoter.ts
@@ -23,12 +23,12 @@ export class RoutingApiQuoter implements Quoter {
     try {
       const req = this.buildRequest(request);
       const now = Date.now();
-      const requestHeaders: QuoteRequestHeaders = {'x-api-key': this.routingApiKey};
+      const requestHeaders: QuoteRequestHeaders = { 'x-api-key': this.routingApiKey };
       if (request.headers['x-request-source']) requestHeaders['x-request-source'] = request.headers['x-request-source'];
       if (request.headers['x-app-version']) requestHeaders['x-app-version'] = request.headers['x-app-version'];
 
       const response = await axios.get<ClassicQuoteDataJSON>(req, {
-        headers: requestHeaders
+        headers: requestHeaders,
       });
       const portionAdjustedResponse: AxiosResponse<ClassicQuoteDataJSON> = {
         ...response,

--- a/test/unit/entities/DutchQuote.test.ts
+++ b/test/unit/entities/DutchQuote.test.ts
@@ -145,8 +145,8 @@ describe('DutchQuote', () => {
     );
 
     it('uses portion from original', async () => {
-      const dutchQuoteNoPortion = createDutchQuote({ amountOut: AMOUNT_LARGE }, 'EXACT_INPUT', '1', FLAT_PORTION, true);
-      const reparameterized = DutchQuote.reparameterize(dutchQuoteNoPortion, CLASSIC_QUOTE_EXACT_IN_LARGE, undefined);
+      const dutchQuotePortion = createDutchQuote({ amountOut: AMOUNT_LARGE }, 'EXACT_INPUT', '1', FLAT_PORTION, true);
+      const reparameterized = DutchQuote.reparameterize(dutchQuotePortion, CLASSIC_QUOTE_EXACT_IN_LARGE, undefined);
       expect(reparameterized.portion?.bips).toEqual(PORTION_BIPS);
       expect(reparameterized.toOrder().toJSON().outputs.length).toEqual(2);
     });

--- a/test/unit/entities/DutchQuote.test.ts
+++ b/test/unit/entities/DutchQuote.test.ts
@@ -144,6 +144,13 @@ describe('DutchQuote', () => {
       }
     );
 
+    it('uses portion from original', async () => {
+      const dutchQuoteNoPortion = createDutchQuote({ amountOut: AMOUNT_LARGE }, 'EXACT_INPUT', '1', FLAT_PORTION, true);
+      const reparameterized = DutchQuote.reparameterize(dutchQuoteNoPortion, CLASSIC_QUOTE_EXACT_IN_LARGE, undefined);
+      expect(reparameterized.portion?.bips).toEqual(PORTION_BIPS);
+      expect(reparameterized.toOrder().toJSON().outputs.length).toEqual(2);
+    });
+
     it('only override auctionPeriodSec on mainnet', async () => {
       const classic = CLASSIC_QUOTE_EXACT_IN_LARGE;
       const dutchRequest = createDutchQuote({ amountOut: AMOUNT_LARGE, chainId: 137 }, 'EXACT_INPUT', '1');

--- a/test/unit/providers/quoters/RoutingApiQuoter.test.ts
+++ b/test/unit/providers/quoters/RoutingApiQuoter.test.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import NodeCache from 'node-cache';
 import { ClassicQuote } from '../../../../lib/entities';
-import { GET_NO_PORTION_RESPONSE, GetPortionResponse, PortionFetcher } from '../../../../lib/fetchers/PortionFetcher';
+import { GetPortionResponse, GET_NO_PORTION_RESPONSE, PortionFetcher } from '../../../../lib/fetchers/PortionFetcher';
 import { RoutingApiQuoter } from '../../../../lib/providers/quoters';
 import axios from '../../../../lib/providers/quoters/helpers';
 import { PORTION_BIPS, PORTION_RECIPIENT } from '../../../constants';
@@ -12,7 +12,7 @@ import {
   makeClassicRequest,
   QUOTE_REQUEST_CLASSIC,
   QUOTE_REQUEST_CLASSIC_FE_ENABLE_FEE_ON_TRANSFER,
-  QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION
+  QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION,
 } from '../../../utils/fixtures';
 
 describe('RoutingApiQuoter', () => {
@@ -168,45 +168,42 @@ describe('RoutingApiQuoter', () => {
     });
 
     it('quote with x-request-source headers', async () => {
-      const request =  makeClassicRequest({});
-      request.headers = {'x-request-source': 'uniswap-ios'};
+      const request = makeClassicRequest({});
+      request.headers = { 'x-request-source': 'uniswap-ios' };
       axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
       const response = await routingApiQuoter.quote(request);
       expect(response).toBeDefined();
       expect(response).toBeInstanceOf(ClassicQuote);
 
-      expect(axiosMock).toHaveBeenCalledWith(
-        expect.any(String),
-        { headers: expect.objectContaining({'x-request-source': 'uniswap-ios'})}
-      )
+      expect(axiosMock).toHaveBeenCalledWith(expect.any(String), {
+        headers: expect.objectContaining({ 'x-request-source': 'uniswap-ios' }),
+      });
     });
 
     it('quote with x-request-source and x-app-version headers', async () => {
-      const request =  makeClassicRequest({});
-      request.headers = {'x-request-source': 'uniswap-ios', 'x-app-version': '1.27'};
+      const request = makeClassicRequest({});
+      request.headers = { 'x-request-source': 'uniswap-ios', 'x-app-version': '1.27' };
       axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
       const response = await routingApiQuoter.quote(request);
       expect(response).toBeDefined();
       expect(response).toBeInstanceOf(ClassicQuote);
 
-      expect(axiosMock).toHaveBeenCalledWith(
-        expect.any(String),
-        { headers: expect.objectContaining({'x-request-source': 'uniswap-ios', 'x-app-version': '1.27'})}
-      )
+      expect(axiosMock).toHaveBeenCalledWith(expect.any(String), {
+        headers: expect.objectContaining({ 'x-request-source': 'uniswap-ios', 'x-app-version': '1.27' }),
+      });
     });
 
     it('quote with x-request-source, x-app-version and aws-timestamp headers, ignores aws header', async () => {
-      const request =  makeClassicRequest({});
-      request.headers = {'x-request-source': 'uniswap-ios', 'x-app-version': '1.27', 'aws-timestamp': '12345678'};
+      const request = makeClassicRequest({});
+      request.headers = { 'x-request-source': 'uniswap-ios', 'x-app-version': '1.27', 'aws-timestamp': '12345678' };
       axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
       const response = await routingApiQuoter.quote(request);
       expect(response).toBeDefined();
       expect(response).toBeInstanceOf(ClassicQuote);
 
-      expect(axiosMock).toHaveBeenCalledWith(
-        expect.any(String),
-        { headers: {'x-api-key': 'test-key', 'x-request-source': 'uniswap-ios', 'x-app-version': '1.27'}}
-      )
+      expect(axiosMock).toHaveBeenCalledWith(expect.any(String), {
+        headers: { 'x-api-key': 'test-key', 'x-request-source': 'uniswap-ios', 'x-app-version': '1.27' },
+      });
     });
   });
 


### PR DESCRIPTION
when requesting dutch only, we build classic request and use its result
to parameterize our portion. however, we do not carry over all the
portion details. This commit updates it to simplify this process and
simply use the portion that already exists in the dutch quote if it is
there
