### PR TITLE
fix: turn on `enableUniversalRouter` for classic param of dutch quotes

### DIFF
--- a/lib/entities/context/DutchQuoteContext.ts
+++ b/lib/entities/context/DutchQuoteContext.ts
@@ -63,6 +63,7 @@ export class DutchQuoteContext implements QuoteContext {
       simulateFromAddress: this.request.config.swapper,
       deadline: DEFAULT_ROUTING_API_DEADLINE,
       recipient: this.request.config.swapper,
+      enableUniversalRouter: true
     });
     this.classicKey = classicRequest.key();
     this.log.info({ classicRequest: classicRequest.info }, 'Adding synthetic classic request');

--- a/test/unit/lib/entities/context/DutchQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/DutchQuoteContext.test.ts
@@ -95,6 +95,8 @@ describe('DutchQuoteContext', () => {
       // second is classic
       expect(deps[1].info).toEqual(request.info);
       expect(deps[1].routingType).toEqual(RoutingType.CLASSIC);
+      const classicRequestConfig = deps[1].config as ClassicConfig;
+      expect(classicRequestConfig.enableUniversalRouter).toEqual(QUOTE_REQUEST_CLASSIC.config.enableUniversalRouter);
     });
   });
 

--- a/test/unit/lib/entities/context/DutchQuoteContext.test.ts
+++ b/test/unit/lib/entities/context/DutchQuoteContext.test.ts
@@ -3,7 +3,7 @@ import Logger from 'bunyan';
 import { BigNumber, ethers } from 'ethers';
 
 import { NATIVE_ADDRESS, RoutingType } from '../../../../../lib/constants';
-import { DutchQuote, DutchQuoteContext, DutchQuoteDataJSON } from '../../../../../lib/entities';
+import { ClassicConfig, DutchQuote, DutchQuoteContext, DutchQuoteDataJSON } from '../../../../../lib/entities';
 import { SyntheticStatusProvider } from '../../../../../lib/providers';
 import { Erc20__factory } from '../../../../../lib/types/ext/factories/Erc20__factory';
 import {
@@ -23,6 +23,7 @@ import {
   createDutchQuoteWithRequest,
   DL_QUOTE_EXACT_IN_BETTER,
   makeDutchRequest,
+  QUOTE_REQUEST_CLASSIC,
   QUOTE_REQUEST_DL,
 } from '../../../../utils/fixtures';
 
@@ -78,6 +79,8 @@ describe('DutchQuoteContext', () => {
       // second is classic
       expect(deps[1].info).toEqual(QUOTE_REQUEST_DL.info);
       expect(deps[1].routingType).toEqual(RoutingType.CLASSIC);
+      const classicRequestConfig = deps[1].config as ClassicConfig;
+      expect(classicRequestConfig.enableUniversalRouter).toEqual(QUOTE_REQUEST_CLASSIC.config.enableUniversalRouter);
     });
 
     it('returns expected dependencies when output is not weth', () => {

--- a/test/unit/providers/quoters/RoutingApiQuoter.test.ts
+++ b/test/unit/providers/quoters/RoutingApiQuoter.test.ts
@@ -210,7 +210,7 @@ describe('RoutingApiQuoter', () => {
   describe('buildRequest', () => {
     it('properly builds query string', async () => {
       expect(await routingApiQuoter.buildRequest(QUOTE_REQUEST_CLASSIC)).toEqual(
-        'https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5'
+        'https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5&enableUniversalRouter=true'
       );
     });
 
@@ -218,7 +218,7 @@ describe('RoutingApiQuoter', () => {
       process.env.ENABLE_PORTION = 'true';
 
       expect(routingApiQuoter.buildRequest(QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION)).toEqual(
-        `https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5&portionBips=${PORTION_BIPS}&portionRecipient=${PORTION_RECIPIENT}`
+        `https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5&enableUniversalRouter=true&portionBips=${PORTION_BIPS}&portionRecipient=${PORTION_RECIPIENT}`
       );
     });
 
@@ -226,7 +226,7 @@ describe('RoutingApiQuoter', () => {
       process.env.ENABLE_PORTION = 'false';
 
       expect(routingApiQuoter.buildRequest(QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION)).toEqual(
-        `https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5`
+        `https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5&enableUniversalRouter=true`
       );
     });
 
@@ -234,7 +234,7 @@ describe('RoutingApiQuoter', () => {
       process.env.ENABLE_PORTION = 'true';
 
       expect(routingApiQuoter.buildRequest(QUOTE_REQUEST_CLASSIC)).toEqual(
-        `https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5`
+        'https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5&enableUniversalRouter=true'
       );
     });
   });

--- a/test/utils/fixtures.ts
+++ b/test/utils/fixtures.ts
@@ -176,6 +176,7 @@ export function makeClassicRequest(overrides: Partial<QuoteRequestBodyJSON>): Cl
         routingType: RoutingType.CLASSIC,
         protocols: ['v3'],
         gasPriceWei: '12',
+        enableUniversalRouter: true
       },
     ],
   }).quoteRequests[0] as ClassicRequest;


### PR DESCRIPTION
# Description

- This PR aims to turn on the `enableUniversalRouter` option for the routing-api request needed to parameterize dutch only quotes
- Integration tests pass
- Still not sure how this was introduced

# Testing
- [X] Unit tests
- [ ] Integration tests
- [X] Manual tests


# Screenshots

<img width="674" alt="Screenshot 2024-04-24 at 4 14 30 PM" src="https://github.com/Uniswap/unified-routing-api/assets/23269489/ffc3784a-0a1b-4141-97fe-3b06f895affd">
<img width="765" alt="Screenshot 2024-04-24 at 4 14 22 PM" src="https://github.com/Uniswap/unified-routing-api/assets/23269489/014cf120-5433-4b41-81fb-b20f7a107a3b">
<img width="527" alt="Screenshot 2024-04-24 at 4 16 33 PM" src="https://github.com/Uniswap/unified-routing-api/assets/23269489/18925a9a-b272-4735-8b7c-aae5ab14234a">

