### PR TITLE
chore: remove portion flags used for development and control

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -166,7 +166,6 @@ export class APIPipeline extends Stack {
         PORTION_API_URL: urlSecrets.secretValueFromJson('PORTION_API_BETA').toString(),
         REQUEST_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_REQUEST_DESTINATION_BETA').toString(),
         RESPONSE_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_RESPONSE_DESTINATION_BETA').toString(),
-        FORCE_PORTION_STRING: portionFlagSecret.secretValueFromJson('FORCE_PORTION_STRING').toString(),
       },
     });
 
@@ -193,7 +192,6 @@ export class APIPipeline extends Stack {
         PORTION_API_URL: urlSecrets.secretValueFromJson('PORTION_API_PROD').toString(),
         REQUEST_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_REQUEST_DESTINATION_PROD').toString(),
         RESPONSE_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_RESPONSE_DESTINATION_PROD').toString(),
-        FORCE_PORTION_STRING: portionFlagSecret.secretValueFromJson('FORCE_PORTION_STRING').toString(),
       },
     });
 
@@ -252,10 +250,6 @@ export class APIPipeline extends Stack {
             value: `${stage}/portion-api/url`,
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
-          FORCE_PORTION_SECRET: {
-            value: 'force-portion-secret',
-            type: BuildEnvironmentVariableType.SECRETS_MANAGER,
-          },
           PARAM_API_URL: {
             value: `${stage}/param-api/url`,
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
@@ -270,7 +264,6 @@ export class APIPipeline extends Stack {
         'echo "PORTION_API_URL=${PORTION_API_URL}" >> .env',
         'echo "ARCHIVE_NODE_RPC=${ARCHIVE_NODE_RPC}" >> .env',
         'echo "URA_INTERNAL_API_KEY=${URA_INTERNAL_API_KEY}" >> .env',
-        'echo "FORCE_PORTION_SECRET=${FORCE_PORTION_SECRET}" >> .env',
         'yarn install --frozen-lockfile --network-concurrency 1',
         'yarn build',
         'yarn test:integ',
@@ -305,7 +298,6 @@ envVars['REQUEST_DESTINATION_ARN'] = process.env['REQUEST_DESTINATION_ARN'] || '
 envVars['RESPONSE_DESTINATION_ARN'] = process.env['RESPONSE_DESTINATION_ARN'] || '';
 envVars['ROUTING_API_KEY'] = process.env['ROUTING_API_KEY'] || 'test-api-key';
 envVars['PARAMETERIZATION_API_KEY'] = process.env['PARAMETERIZATION_API_KEY'] || 'test-api-key';
-envVars['FORCE_PORTION_SECRET'] = process.env['FORCE_PORTION_SECRET'] || '';
 
 const jsonRpcProviders = {} as { [chainKey: string]: string };
 SUPPORTED_CHAINS[RoutingType.CLASSIC].forEach((chainId: ChainId) => {

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -164,7 +164,6 @@ export class APIPipeline extends Stack {
         ROUTING_API_URL: urlSecrets.secretValueFromJson('ROUTING_API_BETA').toString(),
         SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_BETA').toString(),
         PORTION_API_URL: urlSecrets.secretValueFromJson('PORTION_API_BETA').toString(),
-        ENABLE_PORTION: portionFlagSecret.secretValueFromJson('ENABLE_PORTION_BETA').toString(),
         REQUEST_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_REQUEST_DESTINATION_BETA').toString(),
         RESPONSE_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_RESPONSE_DESTINATION_BETA').toString(),
         FORCE_PORTION_STRING: portionFlagSecret.secretValueFromJson('FORCE_PORTION_STRING').toString(),
@@ -192,7 +191,6 @@ export class APIPipeline extends Stack {
         ROUTING_API_URL: urlSecrets.secretValueFromJson('ROUTING_API_PROD').toString(),
         SERVICE_URL: urlSecrets.secretValueFromJson('GOUDA_SERVICE_PROD').toString(),
         PORTION_API_URL: urlSecrets.secretValueFromJson('PORTION_API_PROD').toString(),
-        ENABLE_PORTION: portionFlagSecret.secretValueFromJson('ENABLE_PORTION_PROD').toString(),
         REQUEST_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_REQUEST_DESTINATION_PROD').toString(),
         RESPONSE_DESTINATION_ARN: arnSecrects.secretValueFromJson('URA_RESPONSE_DESTINATION_PROD').toString(),
         FORCE_PORTION_STRING: portionFlagSecret.secretValueFromJson('FORCE_PORTION_STRING').toString(),
@@ -303,7 +301,6 @@ envVars['RFQ_LABS_COSIGNER_ADDRESS'] = process.env['RFQ_LABS_COSIGNER_ADDRESS'] 
 envVars['ROUTING_API_URL'] = process.env['ROUTING_API_URL'] || '';
 envVars['SERVICE_URL'] = process.env['SERVICE_URL'] || '';
 envVars['PORTION_API_URL'] = process.env['PORTION_API_URL'] || '';
-envVars['ENABLE_PORTION'] = process.env['ENABLE_PORTION'] || '';
 envVars['REQUEST_DESTINATION_ARN'] = process.env['REQUEST_DESTINATION_ARN'] || '';
 envVars['RESPONSE_DESTINATION_ARN'] = process.env['RESPONSE_DESTINATION_ARN'] || '';
 envVars['ROUTING_API_KEY'] = process.env['ROUTING_API_KEY'] || 'test-api-key';

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -141,10 +141,6 @@ export class APIPipeline extends Stack {
       secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:UniswapX/ParamApi/ApiKeys-hYyUt1',
     });
 
-    const portionFlagSecret = sm.Secret.fromSecretAttributes(this, 'portion-flag', {
-      secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:portion-flag-yR0VGr',
-    });
-
     // Beta us-east-2
     const betaUsEast2Stage = new APIStage(this, 'beta-us-east-2', {
       env: { account: '665191769009', region: 'us-east-2' },

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,5 +1,4 @@
 import { BigNumber } from 'ethers';
-import { forcePortion } from './util/portion';
 
 export const DEFAULT_SLIPPAGE_TOLERANCE = '0.5'; // 0.5%
 export const DEFAULT_ROUTING_API_DEADLINE = 600; // 10 minutes
@@ -33,23 +32,10 @@ export enum RoutingType {
 export const DEFAULT_POSITIVE_CACHE_ENTRY_TTL = 300; // 5 minutes
 export const DEFAULT_NEGATIVE_CACHE_ENTRY_TTL = 300; // 5 minutes
 
-// we need this functional style of always enquirying the env var,
-// otherwise when assigning process.env.ENABLE_PORTION to const variables,
-// an update in process.env.ENABLE_PORTION will not be reflected in the lambda invocations until lambda recycles.
-export const getEnablePortionEnvVar = () => process.env.ENABLE_PORTION;
-
-export const uraEnablePortion = () => {
-  if (forcePortion) {
-    return true;
-  } else {
-    return getEnablePortionEnvVar() === 'true';
-  }
-};
-
 export const frontendEnablePortion = (sendPortionFlag?: boolean) => {
   return sendPortionFlag;
 };
 
 export const frontendAndUraEnablePortion = (sendPortionFlag?: boolean) => {
-  return frontendEnablePortion(sendPortionFlag) && uraEnablePortion();
+  return frontendEnablePortion(sendPortionFlag);
 };

--- a/lib/fetchers/PortionFetcher.ts
+++ b/lib/fetchers/PortionFetcher.ts
@@ -7,7 +7,6 @@ import { RequestSource } from '../entities';
 import axios from '../providers/quoters/helpers';
 import { log } from '../util/log';
 import { metrics } from '../util/metrics';
-import { forcePortion } from '../util/portion';
 
 export enum PortionType {
   Flat = 'flat',
@@ -62,10 +61,7 @@ export class PortionFetcher {
   ): Promise<GetPortionResponse> {
     metrics.putMetric(`PortionFetcherRequest`, 1);
 
-    // We bypass the cache if `forcePortion` is true.
-    // We do it to avoid cache conflicts since `forcePortion` is only for testing purposes.
     const portionFromCache =
-      !forcePortion &&
       this.portionCache.get<GetPortionResponse>(
         PortionFetcher.PORTION_CACHE_KEY(
           tokenInChainId,
@@ -98,21 +94,17 @@ export class PortionFetcher {
       metrics.putMetric(`PortionFetcherSuccess`, 1);
       metrics.putMetric(`PortionFetcherCacheMiss`, 1);
 
-      // We bypass the cache if `forcePortion` is true.
-      // We do it to avoid cache conflicts since `forcePortion` is only for testing purposes.
-      if (!forcePortion) {
-        this.portionCache.set<GetPortionResponse>(
-          PortionFetcher.PORTION_CACHE_KEY(
-            tokenInChainId,
-            tokenInAddress,
-            tokenOutChainId,
-            tokenOutAddress,
-            requestSource
-          ),
-          portionResponse.data,
-          portionResponse.data.portion ? this.positiveCacheEntryTtl : this.negativeCacheEntryTtl
-        );
-      }
+      this.portionCache.set<GetPortionResponse>(
+        PortionFetcher.PORTION_CACHE_KEY(
+          tokenInChainId,
+          tokenInAddress,
+          tokenOutChainId,
+          tokenOutAddress,
+          requestSource
+        ),
+        portionResponse.data,
+        portionResponse.data.portion ? this.positiveCacheEntryTtl : this.negativeCacheEntryTtl
+      );
 
       return portionResponse.data;
     } catch (e) {

--- a/lib/fetchers/PortionFetcher.ts
+++ b/lib/fetchers/PortionFetcher.ts
@@ -2,7 +2,7 @@ import { Unit } from 'aws-embedded-metrics';
 import * as http from 'http';
 import * as https from 'https';
 import NodeCache from 'node-cache';
-import { DEFAULT_NEGATIVE_CACHE_ENTRY_TTL, DEFAULT_POSITIVE_CACHE_ENTRY_TTL, uraEnablePortion } from '../constants';
+import { DEFAULT_NEGATIVE_CACHE_ENTRY_TTL, DEFAULT_POSITIVE_CACHE_ENTRY_TTL } from '../constants';
 import { RequestSource } from '../entities';
 import axios from '../providers/quoters/helpers';
 import { log } from '../util/log';
@@ -61,13 +61,6 @@ export class PortionFetcher {
     requestSource: RequestSource
   ): Promise<GetPortionResponse> {
     metrics.putMetric(`PortionFetcherRequest`, 1);
-
-    // we check ENABLE_PORTION for every request, so that the update to the lambda env var gets reflected
-    // in real time
-    if (!uraEnablePortion()) {
-      metrics.putMetric(`PortionFetcherFlagDisabled`, 1);
-      return GET_NO_PORTION_RESPONSE;
-    }
 
     // We bypass the cache if `forcePortion` is true.
     // We do it to avoid cache conflicts since `forcePortion` is only for testing purposes.

--- a/lib/handlers/quote/injector.ts
+++ b/lib/handlers/quote/injector.ts
@@ -1,8 +1,7 @@
-import { APIGatewayProxyEvent, Context } from 'aws-lambda';
-import { default as bunyan, default as Logger } from 'bunyan';
-
 import { ChainId } from '@uniswap/sdk-core';
 import { MetricsLogger } from 'aws-embedded-metrics';
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { default as bunyan, default as Logger } from 'bunyan';
 import { providers } from 'ethers';
 import NodeCache from 'node-cache';
 import { SUPPORTED_CHAINS } from '../../config/chains';
@@ -16,11 +15,10 @@ import {
   Quoter,
   RfqQuoter,
   RoutingApiQuoter,
-  SyntheticStatusProvider,
+  SyntheticStatusProvider
 } from '../../providers';
 import { setGlobalLogger } from '../../util/log';
 import { setGlobalMetrics } from '../../util/metrics';
-import { setGlobalForcePortion } from '../../util/portion';
 import { checkDefined } from '../../util/preconditions';
 import { ApiInjector, ApiRInj } from '../base/api-handler';
 
@@ -83,7 +81,7 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, ApiRInj, Quote
     _containerInjected: ContainerInjected,
     requestBody: QuoteRequestBodyJSON,
     _requestQueryParams: void,
-    event: APIGatewayProxyEvent,
+    _event: APIGatewayProxyEvent,
     context: Context,
     log: Logger,
     metrics: MetricsLogger
@@ -95,11 +93,6 @@ export class QuoteInjector extends ApiInjector<ContainerInjected, ApiRInj, Quote
       requestBody: requestBody,
       requestId,
     });
-
-    setGlobalForcePortion(
-      process.env.FORCE_PORTION_STRING !== undefined &&
-        event.headers['X-UNISWAP-FORCE-PORTION-SECRET'] === process.env.FORCE_PORTION_STRING
-    );
 
     setGlobalLogger(log);
 

--- a/lib/providers/quoters/RfqQuoter.ts
+++ b/lib/providers/quoters/RfqQuoter.ts
@@ -31,7 +31,7 @@ export class RfqQuoter implements Quoter {
         ? request.info.amount.mul(request.info.portion.bips).div(BPS)
         : undefined;
 
-    // we will only add portion to the exact out swap amount if the URA ENABLE_PORTION is true
+    // we will only add portion to the exact out swap amount if the portionEnabled is true
     // as well as the frontend sendPortionEnabled is true
     const amount = portionAmount && portionEnabled ? request.info.amount.add(portionAmount) : request.info.amount;
     const requests = [

--- a/lib/util/portion.ts
+++ b/lib/util/portion.ts
@@ -1,3 +1,0 @@
-export let forcePortion = false;
-
-export const setGlobalForcePortion = (_forcePortion: boolean) => (forcePortion = _forcePortion);

--- a/test/integ/base.test.ts
+++ b/test/integ/base.test.ts
@@ -78,7 +78,6 @@ export const axiosHelper = axiosStatic.create({
 const axiosConfig: AxiosRequestConfig<any> = {
   headers: {
     ...(process.env.URA_INTERNAL_API_KEY && { 'x-api-key': process.env.URA_INTERNAL_API_KEY }),
-    ...(process.env.FORCE_PORTION_SECRET && { 'X-UNISWAP-FORCE-PORTION-SECRET': process.env.FORCE_PORTION_SECRET }),
   },
 };
 

--- a/test/integ/base.test.ts
+++ b/test/integ/base.test.ts
@@ -378,7 +378,6 @@ export class BaseIntegrationTestSuite {
       parseAmount('700000', BULLET),
     ]);
 
-    process.env.ENABLE_PORTION = 'true';
     if (process.env.PORTION_API_URL) {
       this.portionFetcher = new PortionFetcher(process.env.PORTION_API_URL, new NodeCache());
     }

--- a/test/unit/entities/DutchQuote.test.ts
+++ b/test/unit/entities/DutchQuote.test.ts
@@ -45,14 +45,6 @@ describe('DutchQuote', () => {
   const logger = Logger.createLogger({ name: 'test' });
   logger.level(Logger.FATAL);
 
-  beforeEach(() => {
-    process.env.ENABLE_PORTION = 'true';
-  });
-
-  afterEach(() => {
-    process.env.ENABLE_PORTION = 'false';
-  });
-
   describe('Reparameterize', () => {
     it('slippage is in percent terms', async () => {
       const amountIn = BigNumber.from('1000000000');

--- a/test/unit/lib/constants.test.ts
+++ b/test/unit/lib/constants.test.ts
@@ -1,43 +1,11 @@
-import { frontendAndUraEnablePortion, frontendEnablePortion, uraEnablePortion } from '../../../lib/constants';
+import { frontendEnablePortion } from '../../../lib/constants';
 
 describe('constants Unit Tests', () => {
-  const enablePortionFlagOptions = ['true', 'false', undefined, 'garbage'];
-
-  enablePortionFlagOptions.forEach((enablePortionFlagOption) => {
-    it(`URA enable portion when process.env.ENABLE_PORTION = ${enablePortionFlagOption}`, () => {
-      process.env.ENABLE_PORTION = enablePortionFlagOption;
-
-      switch (enablePortionFlagOption) {
-        case 'true':
-          expect(uraEnablePortion()).toBeTruthy();
-          break;
-        case 'false':
-          expect(uraEnablePortion()).toBeFalsy();
-          break;
-        default:
-          expect(uraEnablePortion()).toBeFalsy();
-          break;
-      }
-    });
-  });
-
   const sendPortionFlagOptions = [true, false, undefined];
 
   sendPortionFlagOptions.forEach((sendPortionFlag) => {
-    it(`URA enable portion when process.env.ENABLE_PORTION = ${sendPortionFlag}`, () => {
+    it(`URA enable portion when sePortionEnabled = ${sendPortionFlag}`, () => {
       expect(frontendEnablePortion(sendPortionFlag)).toStrictEqual(sendPortionFlag);
-    });
-  });
-
-  enablePortionFlagOptions.forEach((enablePortionFlagOption) => {
-    sendPortionFlagOptions.forEach((sendPortionFlag) => {
-      it(`URA enable portion when process.env.ENABLE_PORTION = ${enablePortionFlagOption} and sendPortionFlag = ${sendPortionFlag}`, () => {
-        process.env.ENABLE_PORTION = enablePortionFlagOption;
-
-        expect(frontendAndUraEnablePortion(sendPortionFlag)).toStrictEqual(
-          sendPortionFlag && enablePortionFlagOption === 'true'
-        );
-      });
     });
   });
 });

--- a/test/unit/lib/fetchers/PortionFetcher.test.ts
+++ b/test/unit/lib/fetchers/PortionFetcher.test.ts
@@ -2,9 +2,9 @@ import { AxiosInstance } from 'axios';
 import NodeCache from 'node-cache';
 import { DEFAULT_NEGATIVE_CACHE_ENTRY_TTL, DEFAULT_POSITIVE_CACHE_ENTRY_TTL } from '../../../../lib/constants';
 import { RequestSource } from '../../../../lib/entities';
-import { GetPortionResponse, GET_NO_PORTION_RESPONSE, PortionFetcher } from '../../../../lib/fetchers/PortionFetcher';
+import { GET_NO_PORTION_RESPONSE, GetPortionResponse, PortionFetcher } from '../../../../lib/fetchers/PortionFetcher';
 import axios from '../../../../lib/providers/quoters/helpers';
-import { forcePortion, setGlobalForcePortion } from '../../../../lib/util/portion';
+import { forcePortion } from '../../../../lib/util/portion';
 import { FLAT_PORTION } from '../../../constants';
 
 function testPortion() {
@@ -160,27 +160,5 @@ function testPortion() {
 }
 
 describe('PortionFetcher Unit Tests', () => {
-  describe('with ENABLE_PORTION flag', () => {
-    beforeEach(() => {
-      process.env.ENABLE_PORTION = 'true';
-      setGlobalForcePortion(false);
-    });
-
-    afterEach(() => {
-      process.env.ENABLE_PORTION = undefined;
-    });
     testPortion();
-  });
-
-  describe('with forcePortion global', () => {
-    beforeEach(() => {
-      process.env.ENABLE_PORTION = undefined;
-      setGlobalForcePortion(true);
-    });
-
-    afterEach(() => {
-      setGlobalForcePortion(false);
-    });
-    testPortion();
-  });
 });

--- a/test/unit/lib/fetchers/PortionFetcher.test.ts
+++ b/test/unit/lib/fetchers/PortionFetcher.test.ts
@@ -4,7 +4,6 @@ import { DEFAULT_NEGATIVE_CACHE_ENTRY_TTL, DEFAULT_POSITIVE_CACHE_ENTRY_TTL } fr
 import { RequestSource } from '../../../../lib/entities';
 import { GET_NO_PORTION_RESPONSE, GetPortionResponse, PortionFetcher } from '../../../../lib/fetchers/PortionFetcher';
 import axios from '../../../../lib/providers/quoters/helpers';
-import { forcePortion } from '../../../../lib/util/portion';
 import { FLAT_PORTION } from '../../../constants';
 
 function testPortion() {
@@ -54,31 +53,27 @@ function testPortion() {
         )
       );
 
-      if (!forcePortion) {
-        expect(cachedPortionData).toBeDefined;
-        expect(cachedPortionData?.portion).toBeDefined;
-        expect(cachedPortionData?.hasPortion).toEqual(true);
-        expect(cachedPortionData?.portion).toStrictEqual(portionResponse.portion);
+      expect(cachedPortionData).toBeDefined;
+      expect(cachedPortionData?.portion).toBeDefined;
+      expect(cachedPortionData?.hasPortion).toEqual(true);
+      expect(cachedPortionData?.portion).toStrictEqual(portionResponse.portion);
 
-        const ttlUpperBoundBuffer = 1; // in seconds
-        const ttl = portionCache.getTtl(
-          PortionFetcher.PORTION_CACHE_KEY(
-            tokenInChainId,
-            tokenInAddress,
-            tokenOutChainId,
-            tokenOutAddress,
-            requestSource
-          )
-        );
-        expect(Math.floor((ttl ?? 0) / 1000)).toBeGreaterThanOrEqual(
-          currentEpochTimeInSeconds + DEFAULT_POSITIVE_CACHE_ENTRY_TTL
-        );
-        expect(Math.floor((ttl ?? 0) / 1000)).toBeLessThanOrEqual(
-          currentEpochTimeInSeconds + DEFAULT_POSITIVE_CACHE_ENTRY_TTL + ttlUpperBoundBuffer
-        );
-      } else {
-        expect(cachedPortionData).toBeUndefined;
-      }
+      const ttlUpperBoundBuffer = 1; // in seconds
+      const ttl = portionCache.getTtl(
+        PortionFetcher.PORTION_CACHE_KEY(
+          tokenInChainId,
+          tokenInAddress,
+          tokenOutChainId,
+          tokenOutAddress,
+          requestSource
+        )
+      );
+      expect(Math.floor((ttl ?? 0) / 1000)).toBeGreaterThanOrEqual(
+        currentEpochTimeInSeconds + DEFAULT_POSITIVE_CACHE_ENTRY_TTL
+      );
+      expect(Math.floor((ttl ?? 0) / 1000)).toBeLessThanOrEqual(
+        currentEpochTimeInSeconds + DEFAULT_POSITIVE_CACHE_ENTRY_TTL + ttlUpperBoundBuffer
+      );
     }
   });
 
@@ -107,29 +102,25 @@ function testPortion() {
       PortionFetcher.PORTION_CACHE_KEY(tokenInChainId, tokenInAddress, tokenOutChainId, tokenOutAddress, requestSource)
     );
 
-    if (!forcePortion) {
-      expect(cachedPortionData).toBeDefined;
-      expect(cachedPortionData?.hasPortion).toEqual(GET_NO_PORTION_RESPONSE.hasPortion);
+    expect(cachedPortionData).toBeDefined;
+    expect(cachedPortionData?.hasPortion).toEqual(GET_NO_PORTION_RESPONSE.hasPortion);
 
-      const ttlUpperBoundBuffer = 1; // in seconds
-      const ttl = portionCache.getTtl(
-        PortionFetcher.PORTION_CACHE_KEY(
-          tokenInChainId,
-          tokenInAddress,
-          tokenOutChainId,
-          tokenOutAddress,
-          requestSource
-        )
-      );
-      expect(Math.floor((ttl ?? 0) / 1000)).toBeGreaterThanOrEqual(
-        currentEpochTimeInSeconds + DEFAULT_NEGATIVE_CACHE_ENTRY_TTL
-      );
-      expect(Math.floor((ttl ?? 0) / 1000)).toBeLessThanOrEqual(
-        currentEpochTimeInSeconds + DEFAULT_NEGATIVE_CACHE_ENTRY_TTL + ttlUpperBoundBuffer
-      );
-    } else {
-      expect(cachedPortionData).toBeUndefined;
-    }
+    const ttlUpperBoundBuffer = 1; // in seconds
+    const ttl = portionCache.getTtl(
+      PortionFetcher.PORTION_CACHE_KEY(
+        tokenInChainId,
+        tokenInAddress,
+        tokenOutChainId,
+        tokenOutAddress,
+        requestSource
+      )
+    );
+    expect(Math.floor((ttl ?? 0) / 1000)).toBeGreaterThanOrEqual(
+      currentEpochTimeInSeconds + DEFAULT_NEGATIVE_CACHE_ENTRY_TTL
+    );
+    expect(Math.floor((ttl ?? 0) / 1000)).toBeLessThanOrEqual(
+      currentEpochTimeInSeconds + DEFAULT_NEGATIVE_CACHE_ENTRY_TTL + ttlUpperBoundBuffer
+    );
   });
 
   it('Portion Service encounters runtime error', async () => {

--- a/test/unit/providers/quoters/RfqQuoter.test.ts
+++ b/test/unit/providers/quoters/RfqQuoter.test.ts
@@ -57,11 +57,9 @@ describe('RfqQuoter test', () => {
         swapper: SWAPPER,
         filler: SWAPPER,
       });
-      process.env.ENABLE_PORTION = undefined;
     });
 
     it('sets numOutputs to 2 if portionEnabled', async () => {
-      process.env.ENABLE_PORTION = 'true';
       await quoter.quote(QUOTE_REQUEST_DL_FE_SEND_PORTION);
       expect(axios.post).toBeCalledWith(
         'https://api.uniswap.org/quote',
@@ -72,18 +70,7 @@ describe('RfqQuoter test', () => {
       );
     });
 
-    it('sets numOutputs to 1 if either FE or BE portion flag is set to false', async () => {
-      process.env.ENABLE_PORTION = 'false';
-      await quoter.quote(QUOTE_REQUEST_DL_FE_SEND_PORTION);
-      expect(axios.post).toBeCalledWith(
-        'https://api.uniswap.org/quote',
-        expect.objectContaining({
-          numOutputs: 1,
-        }),
-        expect.anything()
-      );
-
-      process.env.ENABLE_PORTION = 'true';
+    it('sets numOutputs to 1 if either FE portion flag is set to false', async () => {
       await quoter.quote(QUOTE_REQUEST_DL);
       expect(axios.post).toBeCalledWith(
         'https://api.uniswap.org/quote',
@@ -177,8 +164,6 @@ describe('RfqQuoter test', () => {
     });
 
     it('returns EXACT_INPUT quote with portion', async () => {
-      process.env.ENABLE_PORTION = 'true';
-
       const quote = await quoter.quote(QUOTE_REQUEST_DL_FE_SEND_PORTION);
       expect(quote).toMatchObject({
         chainId: 1,
@@ -221,8 +206,6 @@ describe('RfqQuoter test', () => {
     });
 
     it('returns EXACT_OUTPUT quote with portion', async () => {
-      process.env.ENABLE_PORTION = 'true';
-
       const quote = await quoter.quote(QUOTE_REQUEST_DL_EXACT_OUT_WITH_PORTION);
       expect(quote).toMatchObject({
         chainId: 1,

--- a/test/unit/providers/quoters/RoutingApiQuoter.test.ts
+++ b/test/unit/providers/quoters/RoutingApiQuoter.test.ts
@@ -59,7 +59,6 @@ describe('RoutingApiQuoter', () => {
     });
 
     it('quote with portion with FE portion flag and BE portion flag', async () => {
-      process.env.ENABLE_PORTION = 'true';
       axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA_WITH_PORTION.quote });
       const response = await routingApiQuoter.quote(QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION);
       expect(response).toBeDefined();
@@ -72,22 +71,8 @@ describe('RoutingApiQuoter', () => {
     });
 
     it('quote with portion no FE flag', async () => {
-      process.env.ENABLE_PORTION = 'true';
       axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
       const response = await routingApiQuoter.quote(QUOTE_REQUEST_CLASSIC);
-      expect(response).toBeDefined();
-      expect(response).toBeInstanceOf(ClassicQuote);
-
-      const classicQuote = response as ClassicQuote;
-
-      expect(classicQuote.toJSON().portionBips).toBeUndefined;
-      expect(classicQuote.toJSON().portionRecipient).toBeUndefined;
-    });
-
-    it('quote with portion no BE flag', async () => {
-      process.env.ENABLE_PORTION = 'false';
-      axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
-      const response = await routingApiQuoter.quote(QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION);
       expect(response).toBeDefined();
       expect(response).toBeInstanceOf(ClassicQuote);
 
@@ -104,7 +89,6 @@ describe('RoutingApiQuoter', () => {
       jest.spyOn(portionFetcher, 'getPortion').mockResolvedValue(portionResponse);
       const routingApiQuoter = new RoutingApiQuoter('https://api.uniswap.org/', 'test-key');
 
-      process.env.ENABLE_PORTION = 'true';
       axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
       const response = await routingApiQuoter.quote(QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION);
       expect(response).toBeDefined();
@@ -123,28 +107,8 @@ describe('RoutingApiQuoter', () => {
       jest.spyOn(portionFetcher, 'getPortion').mockResolvedValue(portionResponse);
       const routingApiQuoter = new RoutingApiQuoter('https://api.uniswap.org/', 'test-key');
 
-      process.env.ENABLE_PORTION = 'true';
       axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
       const response = await routingApiQuoter.quote(QUOTE_REQUEST_CLASSIC);
-      expect(response).toBeDefined();
-      expect(response).toBeInstanceOf(ClassicQuote);
-
-      const classicQuote = response as ClassicQuote;
-
-      expect(classicQuote.toJSON().portionBips).toBeUndefined;
-      expect(classicQuote.toJSON().portionRecipient).toBeUndefined;
-    });
-
-    it('quote with portion no bips no BE flag', async () => {
-      const portionResponse: GetPortionResponse = GET_NO_PORTION_RESPONSE;
-      const portionCache = new NodeCache({ stdTTL: 600 });
-      const portionFetcher = new PortionFetcher('https://portion.uniswap.org/', portionCache);
-      jest.spyOn(portionFetcher, 'getPortion').mockResolvedValue(portionResponse);
-      const routingApiQuoter = new RoutingApiQuoter('https://api.uniswap.org/', 'test-key');
-
-      process.env.ENABLE_PORTION = 'false';
-      axiosMock.mockResolvedValue({ data: CLASSIC_QUOTE_DATA.quote });
-      const response = await routingApiQuoter.quote(QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION);
       expect(response).toBeDefined();
       expect(response).toBeInstanceOf(ClassicQuote);
 
@@ -215,24 +179,12 @@ describe('RoutingApiQuoter', () => {
     });
 
     it('properly builds query string with FE portion flag and BE portion flag', () => {
-      process.env.ENABLE_PORTION = 'true';
-
       expect(routingApiQuoter.buildRequest(QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION)).toEqual(
         `https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5&portionBips=${PORTION_BIPS}&portionRecipient=${PORTION_RECIPIENT}`
       );
     });
 
-    it('properly builds query string with only FE portion flag', () => {
-      process.env.ENABLE_PORTION = 'false';
-
-      expect(routingApiQuoter.buildRequest(QUOTE_REQUEST_CLASSIC_FE_SEND_PORTION)).toEqual(
-        `https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5`
-      );
-    });
-
     it('properly builds query string with only BE portion flag', () => {
-      process.env.ENABLE_PORTION = 'true';
-
       expect(routingApiQuoter.buildRequest(QUOTE_REQUEST_CLASSIC)).toEqual(
         `https://api.uniswap.org/quote?tokenInAddress=0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984&tokenInChainId=1&tokenOutAddress=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&tokenOutChainId=1&amount=1000000000000000000&type=exactIn&protocols=v3&gasPriceWei=12&slippageTolerance=0.5`
       );


### PR DESCRIPTION
The force-portion secret was used in testing and development, but it is no longer needed now that portion is on by default.

The flag ENABLE_PORTION was used for control, but we now have feature switches in FeeService which we can use to turn on or off the portion.
