### PR TITLE
Improve typing on ChainConfigManager

### DIFF
--- a/lib/config/ChainConfigManager.ts
+++ b/lib/config/ChainConfigManager.ts
@@ -1,33 +1,31 @@
 import { ChainId } from '@uniswap/sdk-core';
 import { RoutingType } from '../constants';
 
-type CommonConfig = {
-  routingType: RoutingType;
+type CommonConfig = {}
+
+export type DutchConfig = {
+  skipRFQ?: boolean;
   priceImprovementBps?: number;
   stdAuctionPeriodSecs?: number;
   deadlineBufferSecs?: number;
 }
 
-export type DutchConfig = CommonConfig & {
-  routingType: RoutingType.DUTCH_LIMIT | RoutingType.DUTCH_V2;
-  skipRFQ?: boolean;
+type RoutingTypeConfig = Partial<{
+  [RoutingType.DUTCH_LIMIT]: DutchConfig & {
+    largeAuctionPeriodSecs?: number;
+  },
+  [RoutingType.DUTCH_V2]: DutchConfig,
+  [RoutingType.RELAY]: CommonConfig,
+  [RoutingType.CLASSIC]: CommonConfig,
+}>;
+
+type ChainConfigType = {
+  routingTypes: RoutingTypeConfig,
+  alarmEnabled: boolean;
 }
 
-type ChainConfig = {
-  routingTypes: (
-    | CommonConfig & {
-        routingType: RoutingType.CLASSIC | RoutingType.RELAY;
-      }
-    | DutchConfig & {
-        routingType: RoutingType.DUTCH_V2;
-      }
-    | DutchConfig & {
-        routingType: RoutingType.DUTCH_LIMIT;
-        largeAuctionPeriodSecs?: number;
-      }
-  )[];
-  alarmEnabled: boolean;
-};
+type ChainConfigMap = { [chainId: number]: ChainConfigType };
+type RouteChainMap = { [routeType: string]: number[] };
 
 export abstract class ChainConfigManager {
   // Represents the other route dependencies for each route type
@@ -37,189 +35,174 @@ export abstract class ChainConfigManager {
     [RoutingType.DUTCH_LIMIT]: [RoutingType.CLASSIC],
     [RoutingType.DUTCH_V2]: [RoutingType.CLASSIC],
   };
-  private static readonly _chainConfigs: { [chainId: number]: ChainConfig } = {
+  private static readonly _chainConfigs: ChainConfigMap = {
     [ChainId.MAINNET]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
+      routingTypes: {
+        [RoutingType.CLASSIC]: {},
+        [RoutingType.RELAY]: {},
+        [RoutingType.DUTCH_LIMIT]: {
+          largeAuctionPeriodSecs: 120
         },
-        {
-          routingType: RoutingType.DUTCH_LIMIT,
-          largeAuctionPeriodSecs: 120,
-        },
-        {
-          routingType: RoutingType.RELAY,
-        },
-        {
-          routingType: RoutingType.DUTCH_V2,
+        [RoutingType.DUTCH_V2]: {
           // 25 blocks from now
           // to cover time to sign, run secondary auction, and some blocks for decay
-          deadlineBufferSecs: 300,
-        },
-      ],
+          deadlineBufferSecs: 300
+        }
+      },
       alarmEnabled: true,
     },
     [ChainId.OPTIMISM]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: true,
     },
     [ChainId.OPTIMISM_GOERLI]: {
       // TODO: add back optimism GOERLI once we are sure routing api supports it
-      routingTypes: [],
+      routingTypes: {},
+      alarmEnabled: false,
+    },
+    [ChainId.OPTIMISM_SEPOLIA]: {
+      routingTypes: {},
       alarmEnabled: false,
     },
     [ChainId.ARBITRUM_ONE]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-        {
-          routingType: RoutingType.DUTCH_V2,
-          skipRFQ: true,
-          priceImprovementBps: 2,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {},
+        [RoutingType.DUTCH_V2]: {
+                  skipRFQ: true,
+                  priceImprovementBps: 2
+        }
+      },
       alarmEnabled: true,
     },
     [ChainId.ARBITRUM_GOERLI]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
+      alarmEnabled: false,
+    },
+    [ChainId.ARBITRUM_SEPOLIA]: {
+      routingTypes: {},
       alarmEnabled: false,
     },
     [ChainId.POLYGON]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-        {
-          routingType: RoutingType.DUTCH_LIMIT,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {},
+        [RoutingType.DUTCH_LIMIT]: {}
+      },
       alarmEnabled: true,
     },
     [ChainId.POLYGON_MUMBAI]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: false,
     },
     [ChainId.GOERLI]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-        {
-          routingType: RoutingType.DUTCH_LIMIT,
-        },
-      ],
-      alarmEnabled: true,
+      routingTypes: {
+        [RoutingType.CLASSIC]: {},
+        [RoutingType.DUTCH_LIMIT]: {}
+      },
+      alarmEnabled: false,
+    },
+    [ChainId.GNOSIS]: {
+      routingTypes: {},
+      alarmEnabled: false,
     },
     [ChainId.SEPOLIA]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: false,
     },
     [ChainId.CELO]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: true,
     },
     [ChainId.CELO_ALFAJORES]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: false,
     },
     [ChainId.BNB]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: true,
     },
     [ChainId.AVALANCHE]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: true,
     },
     [ChainId.BASE_GOERLI]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: false,
     },
     [ChainId.BASE]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: true,
     },
     [ChainId.BLAST]: {
-      routingTypes: [
-        {
-          routingType: RoutingType.CLASSIC,
-        },
-      ],
+      routingTypes: {
+        [RoutingType.CLASSIC]: {}
+      },
       alarmEnabled: true,
     },
-  };
+    [ChainId.MOONBEAM]: {
+      routingTypes: {},
+      alarmEnabled: false,
+    },
+    [ChainId.ZORA]: {
+      routingTypes: {},
+      alarmEnabled: false,
+    },
+    [ChainId.ZORA_SEPOLIA]: {
+      routingTypes: {},
+      alarmEnabled: false,
+    },
+    [ChainId.ROOTSTOCK]: {
+      routingTypes: {},
+      alarmEnabled: false,
+    }
+  }
 
-  private static _chainConfigsWithDependencies: { [chainId: number]: ChainConfig };
-  private static _reverseConfigs: { [routeType: string]: number[] };
+  private static _performedDependencyCheck: boolean = false;
+  private static _reverseConfigs: RouteChainMap;
 
   /**
-   * Lazy load the full list
-   * Adds dependencies if they don't already exist
+   * Checks for dependencies and throws an error if any are missing
    */
-  static get chainConfigsWithDependencies(): { [chainId: number]: ChainConfig } {
-    if (ChainConfigManager._chainConfigsWithDependencies) {
-      return ChainConfigManager._chainConfigsWithDependencies;
-    }
-    ChainConfigManager._chainConfigsWithDependencies = ChainConfigManager._chainConfigs;
-    for (const dependencyMapping in ChainConfigManager._routeDependencies) {
-      for (const dependency of ChainConfigManager._routeDependencies[dependencyMapping]) {
-        for (const chainId in ChainConfigManager._chainConfigs) {
-          let dependentPresent = false;
-          let dependencyPresent = false;
-          for (const supportedRoutingType of ChainConfigManager._chainConfigs[chainId].routingTypes) {
-            dependentPresent = dependentPresent || supportedRoutingType.routingType == dependencyMapping;
-            dependencyPresent = dependencyPresent || supportedRoutingType.routingType == dependency;
-          }
-          // If we have the dependent but not the dependency, add it
-          if (dependentPresent && !dependencyPresent) {
-            ChainConfigManager._chainConfigsWithDependencies[chainId].routingTypes.push({
-              routingType: dependency as RoutingType,
-            });
+  static get chainConfigsWithDependencies(): ChainConfigMap {
+    if (!ChainConfigManager._performedDependencyCheck) {
+      for (const dependencyMapping in ChainConfigManager._routeDependencies) {
+        for (const dependency of ChainConfigManager._routeDependencies[dependencyMapping]) {
+          for (const chainId in ChainConfigManager._chainConfigs) {
+            let dependentPresent = false;
+            let dependencyPresent = false;
+            for (const supportedRoutingType in ChainConfigManager._chainConfigs[chainId].routingTypes) {
+              dependentPresent = dependentPresent || supportedRoutingType == dependencyMapping;
+              dependencyPresent = dependencyPresent || supportedRoutingType == dependency;
+            }
+            // If we have the dependent but not the dependency, add it
+            if (dependentPresent && !dependencyPresent) {
+              throw new Error(`ChainId ${chainId} has routingType ${dependencyMapping} but missing dependency ${dependency}`);
+            }
           }
         }
       }
     }
-    return ChainConfigManager._chainConfigsWithDependencies;
+    ChainConfigManager._performedDependencyCheck = true;
+    return ChainConfigManager._chainConfigs;
   }
 
   static get reverseConfigs(): { [routeType: string]: number[] } {
@@ -228,11 +211,11 @@ export abstract class ChainConfigManager {
     }
     ChainConfigManager._reverseConfigs = {};
     for (const chainId in ChainConfigManager.chainConfigsWithDependencies) {
-      for (const supportedRoutingType of ChainConfigManager.chainConfigsWithDependencies[chainId].routingTypes) {
-        if (!ChainConfigManager._reverseConfigs[supportedRoutingType.routingType]) {
-          ChainConfigManager._reverseConfigs[supportedRoutingType.routingType] = [];
+      for (const supportedRoutingType in ChainConfigManager.chainConfigsWithDependencies[chainId].routingTypes) {
+        if (!ChainConfigManager._reverseConfigs[supportedRoutingType]) {
+          ChainConfigManager._reverseConfigs[supportedRoutingType] = [];
         }
-        ChainConfigManager._reverseConfigs[supportedRoutingType.routingType].push(parseInt(chainId));
+        ChainConfigManager._reverseConfigs[supportedRoutingType].push(parseInt(chainId));
       }
     }
     return ChainConfigManager._reverseConfigs;
@@ -275,7 +258,7 @@ export abstract class ChainConfigManager {
   public static chainSupportsRoutingType(chainId: ChainId, routingType: RoutingType) {
     return (
       chainId in ChainConfigManager.chainConfigsWithDependencies &&
-      ChainConfigManager.chainConfigsWithDependencies[chainId].routingTypes.some((r) => r.routingType == routingType)
+      ChainConfigManager.chainConfigsWithDependencies[chainId].routingTypes[routingType] !== undefined
     );
   }
 
@@ -284,17 +267,15 @@ export abstract class ChainConfigManager {
    * @param routingType the RoutingType to check
    * @returns the QuoteConfig for the provided ChainId and RoutingType
    */
-  public static getQuoteConfig(chainId: ChainId, routingType: RoutingType) {
+  public static getQuoteConfig<T extends RoutingType>(chainId: ChainId, routingType: T): RoutingTypeConfig[T] {
     if (!(chainId in ChainConfigManager.chainConfigsWithDependencies)) {
       throw new Error(`Unexpected chainId ${chainId}`);
     }
-    // Should only return one element if exists
-    const quoteConfig = ChainConfigManager.chainConfigsWithDependencies[chainId].routingTypes.find(
-      (r) => r.routingType == routingType
-    );
+
+    const quoteConfig = ChainConfigManager.chainConfigsWithDependencies[chainId].routingTypes[routingType];
     if (!quoteConfig) {
       throw new Error(`Routing type ${routingType} not supported on chain ${chainId}`);
     }
-    return quoteConfig;
+    return quoteConfig as RoutingTypeConfig[T];
   }
 }

--- a/lib/config/ChainConfigManager.ts
+++ b/lib/config/ChainConfigManager.ts
@@ -13,7 +13,7 @@ export type DutchOverrides = IntentOverrides & {
   priceImprovementBps?: number;
 }
 
-type RoutingTypeConfig = Partial<{
+type RoutingTypeOverrides = Partial<{
   [RoutingType.DUTCH_LIMIT]: DutchOverrides & {
     largeAuctionPeriodSecs?: number;
   },
@@ -23,7 +23,7 @@ type RoutingTypeConfig = Partial<{
 }>;
 
 type ChainConfigType = {  
-  routingTypes: RoutingTypeConfig,
+  routingTypes: RoutingTypeOverrides,
   alarmEnabled: boolean;
 }
 
@@ -197,7 +197,7 @@ export abstract class ChainConfigManager {
               dependentPresent = dependentPresent || supportedRoutingType == dependencyMapping;
               dependencyPresent = dependencyPresent || supportedRoutingType == dependency;
             }
-            // If we have the dependent but not the dependency, add it
+            // If we have the dependent but not the dependency, fail fast
             if (dependentPresent && !dependencyPresent) {
               throw new Error(`ChainId ${chainId} has routingType ${dependencyMapping} but missing dependency ${dependency}`);
             }
@@ -271,7 +271,7 @@ export abstract class ChainConfigManager {
    * @param routingType the RoutingType to check
    * @returns the QuoteConfig for the provided ChainId and RoutingType
    */
-  public static getQuoteConfig<T extends RoutingType>(chainId: ChainId, routingType: T): Exclude<RoutingTypeConfig[T], undefined> {
+  public static getQuoteConfig<T extends RoutingType>(chainId: ChainId, routingType: T): Exclude<RoutingTypeOverrides[T], undefined> {
     if (!(chainId in ChainConfigManager.chainConfigsWithDependencies)) {
       throw new Error(`Unexpected chainId ${chainId}`);
     }
@@ -280,6 +280,6 @@ export abstract class ChainConfigManager {
     if (!quoteConfig) {
       throw new Error(`Routing type ${routingType} not supported on chain ${chainId}`);
     }
-    return quoteConfig as Exclude<RoutingTypeConfig[T], undefined>;
+    return quoteConfig as Exclude<RoutingTypeOverrides[T], undefined>;
   }
 }

--- a/lib/entities/context/DutchQuoteContext.ts
+++ b/lib/entities/context/DutchQuoteContext.ts
@@ -8,7 +8,7 @@ import Logger from 'bunyan';
 import { BigNumber, ethers } from 'ethers';
 import NodeCache from 'node-cache';
 import { QuoteByKey, QuoteContext } from '.';
-import { ChainConfigManager, DutchConfig } from '../../config/ChainConfigManager';
+import { ChainConfigManager } from '../../config/ChainConfigManager';
 import { DEFAULT_ROUTING_API_DEADLINE, LARGE_TRADE_USD_THRESHOLD, NATIVE_ADDRESS } from '../../constants';
 import {
   ClassicQuote,
@@ -136,7 +136,7 @@ export class DutchQuoteContext implements QuoteContext {
       return null;
     }
 
-    const quoteConfig = ChainConfigManager.getQuoteConfig(quote.chainId, this.request.routingType) as DutchConfig;
+    const quoteConfig = ChainConfigManager.getQuoteConfig(quote.chainId, this.request.routingType);
     if (quoteConfig.skipRFQ) {
       this.log.info('RFQ Orders are disabled in config');
       return null;
@@ -200,7 +200,7 @@ export class DutchQuoteContext implements QuoteContext {
 
     const syntheticStatus = await this.syntheticStatusProvider.getStatus(this.request.info);
     const chainId = classicQuote.request.info.tokenInChainId;
-    const quoteConfig = ChainConfigManager.getQuoteConfig(chainId, this.request.routingType) as DutchConfig;
+    const quoteConfig = ChainConfigManager.getQuoteConfig(chainId, this.request.routingType);
     // if the useSyntheticQuotes override is not set by client or server and we're not skipping RFQ, return null
     // if we are skipping RFQ, we need a synthetic quote
     if (!this.request.config.useSyntheticQuotes && !syntheticStatus.syntheticEnabled && !quoteConfig.skipRFQ) {

--- a/lib/entities/quote/DutchV1Quote.ts
+++ b/lib/entities/quote/DutchV1Quote.ts
@@ -100,7 +100,6 @@ export class DutchV1Quote extends DutchQuote<DutchV1Request> implements IQuote {
 
     const quoteConfig = ChainConfigManager.getQuoteConfig(this.chainId, this.request.routingType);
     if (
-      quoteConfig.routingType == RoutingType.DUTCH_LIMIT &&
       quoteConfig.largeAuctionPeriodSecs &&
       this.derived.largeTrade
     ) {

--- a/lib/entities/quote/RelayQuote.ts
+++ b/lib/entities/quote/RelayQuote.ts
@@ -244,7 +244,7 @@ export class RelayQuote implements IQuote {
       return this.request.config.auctionPeriodSecs;
     }
 
-    const quoteConfig = ChainConfigManager.getQuoteConfig(this.chainId, this.request.routingType);
+    const quoteConfig = ChainConfigManager.getQuoteConfig(this.chainId, RoutingType.RELAY);
     return quoteConfig.stdAuctionPeriodSecs ?? DEFAULT_AUCTION_PERIOD_SECS;
   }
 

--- a/test/unit/lib/config/ChainConfigManager.test.ts
+++ b/test/unit/lib/config/ChainConfigManager.test.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@uniswap/sdk-core';
 import Logger from 'bunyan';
 import { BigNumber } from 'ethers';
-import { ChainConfigManager } from '../../../../lib/config/ChainConfigManager';
+import { ChainConfigManager, ChainConfigMap, DependencyMap } from '../../../../lib/config/ChainConfigManager';
 import { BPS, NATIVE_ADDRESS, QuoteType, RoutingType } from '../../../../lib/constants';
 import { DutchQuote, DutchQuoteContext, RelayQuoteContext } from '../../../../lib/entities';
 import { DutchV1Quote } from '../../../../lib/entities/quote/DutchV1Quote';
@@ -52,9 +52,9 @@ describe('ChainConfigManager', () => {
 
   // Reset ChainConfigManager lazy loading to test changes for each test case
   // Necessary whenever we're changing _chainConfigs or _routeDependencies
-  function setChainConfigManager(chainConfigs?: any, routeDependencies?: any) {
-    Object.defineProperty(ChainConfigManager, '_reverseConfigs', { value: undefined });
-    Object.defineProperty(ChainConfigManager, '_chainConfigsWithDependencies', { value: undefined });
+  function setChainConfigManager(chainConfigs?: ChainConfigMap, routeDependencies?: DependencyMap) {
+    Object.defineProperty(ChainConfigManager, '_chainsByRoutingType', { value: undefined });
+    Object.defineProperty(ChainConfigManager, '_performedDependencyCheck', { value: false });
     if (chainConfigs) {
       Object.defineProperty(ChainConfigManager, '_chainConfigs', { value: chainConfigs });
     }
@@ -74,11 +74,11 @@ describe('ChainConfigManager', () => {
     it('getChainIds returns all chains', () => {
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [],
+          routingTypes: {},
           alarmEnabled: false,
         },
         [ChainId.OPTIMISM_GOERLI]: {
-          routingTypes: [],
+          routingTypes: {},
           alarmEnabled: false,
         },
       });
@@ -88,59 +88,40 @@ describe('ChainConfigManager', () => {
       expect(chainIds.includes(ChainId.OPTIMISM_GOERLI)).toBeTruthy();
     });
 
-    it('getChainIds includes routeDependencies', () => {
+    it('getChainIds throws an error if routeDependencies are not present', () => {
       setChainConfigManager(
         {
           [ChainId.MAINNET]: {
-            routingTypes: [
-              {
-                routingType: RoutingType.DUTCH_V2,
-              },
-            ],
+            routingTypes: {
+              [RoutingType.DUTCH_V2]: {},
+            },
             alarmEnabled: false,
-          },
-          [ChainId.OPTIMISM_GOERLI]: {
-            routingTypes: [
-              {
-                routingType: RoutingType.DUTCH_LIMIT,
-              },
-            ],
-            alarmEnabled: false,
-          },
+          }
         },
         {
-          [RoutingType.DUTCH_LIMIT]: [RoutingType.CLASSIC],
           [RoutingType.DUTCH_V2]: [RoutingType.CLASSIC],
         }
       );
-      // chainConfigs doesn't contain Mainnet but it should still
-      // show in getChainIdsByRoutingType since it's listed as a dependency
-      const chainIds = ChainConfigManager.getChainIdsByRoutingType(RoutingType.CLASSIC);
-      expect(chainIds.length == 2).toBeTruthy();
-      expect(chainIds.includes(ChainId.MAINNET)).toBeTruthy();
-      expect(chainIds.includes(ChainId.OPTIMISM_GOERLI)).toBeTruthy();
+      // chainConfigs doesn't contain Classic but its listed as a dependency
+      expect(() => {
+        ChainConfigManager.getChainIdsByRoutingType(RoutingType.CLASSIC);        
+      }).toThrow(`ChainId ${ChainId.MAINNET} has routingType ${RoutingType.DUTCH_V2} but missing dependency ${RoutingType.CLASSIC}`)
     });
 
     it('getChainIdsByRoutingType returns all chains by routing type', () => {
       setChainConfigManager(
         {
           [ChainId.MAINNET]: {
-            routingTypes: [
-              {
-                routingType: RoutingType.CLASSIC,
-              },
-              {
-                routingType: RoutingType.DUTCH_LIMIT,
-              },
-            ],
+            routingTypes: {
+              [RoutingType.CLASSIC]: {},
+              [RoutingType.DUTCH_LIMIT]: {},
+            },
             alarmEnabled: false,
           },
           [ChainId.OPTIMISM_GOERLI]: {
-            routingTypes: [
-              {
-                routingType: RoutingType.DUTCH_LIMIT,
-              },
-            ],
+            routingTypes: {
+              [RoutingType.DUTCH_LIMIT]: {},
+            },
             alarmEnabled: false,
           },
         },
@@ -164,11 +145,11 @@ describe('ChainConfigManager', () => {
     it('getAlarmedChainIds returns all chains by alarm setting', () => {
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [],
+          routingTypes: {},
           alarmEnabled: true,
         },
         [ChainId.OPTIMISM_GOERLI]: {
-          routingTypes: [],
+          routingTypes: {},
           alarmEnabled: false,
         },
       });
@@ -180,18 +161,14 @@ describe('ChainConfigManager', () => {
     it('chainSupportsRoutingType returns true when chainId support routingType', () => {
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [
-            {
-              routingType: RoutingType.CLASSIC,
-            },
-            {
-              routingType: RoutingType.DUTCH_LIMIT,
-            },
-          ],
+          routingTypes: {
+            [RoutingType.CLASSIC]: {},
+            [RoutingType.DUTCH_LIMIT]: {},
+          },
           alarmEnabled: false,
         },
         [ChainId.OPTIMISM_GOERLI]: {
-          routingTypes: [],
+          routingTypes: {},
           alarmEnabled: false,
         },
       });
@@ -205,19 +182,18 @@ describe('ChainConfigManager', () => {
     it('getQuoteConfig returns the QuoteConfig for the provided chainId and routingType', () => {
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [
+          routingTypes: {
+            [RoutingType.CLASSIC]: {},
+            [RoutingType.DUTCH_V2]:
             {
-              routingType: RoutingType.DUTCH_V2,
               stdAuctionPeriodSecs: 99,
             },
-            {
-              routingType: RoutingType.DUTCH_LIMIT,
-            },
-          ],
+            [RoutingType.DUTCH_LIMIT]: {},
+          },
           alarmEnabled: false,
         },
         [ChainId.OPTIMISM_GOERLI]: {
-          routingTypes: [],
+          routingTypes: {},
           alarmEnabled: false,
         },
       });
@@ -238,11 +214,9 @@ describe('ChainConfigManager', () => {
     it('Missing chainId cannot be used with Classic', () => {
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [
-            {
-              routingType: RoutingType.CLASSIC,
-            },
-          ],
+          routingTypes: {
+            [RoutingType.CLASSIC]: {},
+          },
           alarmEnabled: false,
         },
       });
@@ -255,11 +229,10 @@ describe('ChainConfigManager', () => {
     it('Missing chainId cannot be used with Dutch', () => {
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [
-            {
-              routingType: RoutingType.DUTCH_LIMIT,
-            },
-          ],
+          routingTypes: {
+            [RoutingType.CLASSIC]: {},
+            [RoutingType.DUTCH_LIMIT]: {},
+          },
           alarmEnabled: false,
         },
       });
@@ -278,11 +251,10 @@ describe('ChainConfigManager', () => {
     it('Missing chainId cannot be used with Dutchv2', () => {
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [
-            {
-              routingType: RoutingType.DUTCH_V2,
-            },
-          ],
+          routingTypes: {
+            [RoutingType.CLASSIC]: {},
+            [RoutingType.DUTCH_V2]: {},
+          },
           alarmEnabled: false,
         },
       });
@@ -301,11 +273,9 @@ describe('ChainConfigManager', () => {
     it('Missing chainId cannot be used with Relay', () => {
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [
-            {
-              routingType: RoutingType.RELAY,
-            },
-          ],
+          routingTypes: {
+            [RoutingType.RELAY]: {},
+          },
           alarmEnabled: false,
         },
       });
@@ -318,7 +288,7 @@ describe('ChainConfigManager', () => {
     it('Missing routingType cannot be used with chain', () => {
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [],
+          routingTypes: {},
           alarmEnabled: false,
         },
       });
@@ -330,11 +300,9 @@ describe('ChainConfigManager', () => {
 
       setChainConfigManager({
         [ChainId.MAINNET]: {
-          routingTypes: [
-            {
-              routingType: RoutingType.DUTCH_LIMIT,
-            },
-          ],
+          routingTypes: {
+            [RoutingType.DUTCH_LIMIT]: {},
+          },
           alarmEnabled: false,
         },
       });
@@ -352,11 +320,10 @@ describe('ChainConfigManager', () => {
         setChainConfigManager(
           {
             [ChainId.MAINNET]: {
-              routingTypes: [
-                {
-                  routingType: routingType,
-                },
-              ],
+              routingTypes: {
+                [RoutingType.CLASSIC]: {},
+                [routingType]: {}
+              },
               alarmEnabled: false,
             },
           },
@@ -413,12 +380,12 @@ describe('ChainConfigManager', () => {
         setChainConfigManager(
           {
             [ChainId.MAINNET]: {
-              routingTypes: [
-                {
-                  routingType: routingType,
-                  skipRFQ: true,
-                },
-              ],
+              routingTypes: {
+                [RoutingType.CLASSIC]: {},
+                [routingType]: {
+                  skipRFQ: true
+                }
+              },
               alarmEnabled: false,
             },
           },
@@ -444,12 +411,12 @@ describe('ChainConfigManager', () => {
         setChainConfigManager(
           {
             [ChainId.MAINNET]: {
-              routingTypes: [
-                {
-                  routingType: routingType,
-                  skipRFQ: true,
+              routingTypes: {
+                [RoutingType.CLASSIC]: {},
+                [routingType]: {
+                  skipRFQ: true
                 },
-              ],
+              },
               alarmEnabled: false,
             },
           },
@@ -510,13 +477,14 @@ describe('ChainConfigManager', () => {
         setChainConfigManager(
           {
             [ChainId.MAINNET]: {
-              routingTypes: [
-                {
-                  routingType: routingType,
-                  priceImprovementBps: 1,
-                  skipRFQ: true,
-                },
-              ],
+              routingTypes: {
+                [RoutingType.CLASSIC]: {},
+                [routingType]:
+                  {
+                    priceImprovementBps: 1,
+                    skipRFQ: true,
+                  },
+              },
               alarmEnabled: false,
             },
           },
@@ -574,13 +542,14 @@ describe('ChainConfigManager', () => {
         setChainConfigManager(
           {
             [ChainId.MAINNET]: {
-              routingTypes: [
-                {
-                  routingType: routingType,
-                  priceImprovementBps: 10,
-                  skipRFQ: true,
-                },
-              ],
+              routingTypes: {
+                [RoutingType.CLASSIC]: {},
+                [routingType]:
+                  {
+                    priceImprovementBps: 10,
+                    skipRFQ: true,
+                  },
+              },
               alarmEnabled: false,
             },
           },
@@ -606,12 +575,13 @@ describe('ChainConfigManager', () => {
       setChainConfigManager(
         {
           [ChainId.MAINNET]: {
-            routingTypes: [
-              {
-                routingType: RoutingType.DUTCH_LIMIT,
-                skipRFQ: true,
-              },
-            ],
+            routingTypes: {
+              [RoutingType.CLASSIC]: {},
+              [RoutingType.DUTCH_LIMIT]:
+                {
+                  skipRFQ: true,
+                },
+            },
             alarmEnabled: false,
           },
         },
@@ -652,12 +622,13 @@ describe('ChainConfigManager', () => {
       setChainConfigManager(
         {
           [ChainId.MAINNET]: {
-            routingTypes: [
-              {
-                routingType: RoutingType.DUTCH_LIMIT,
-                stdAuctionPeriodSecs: 9999,
-              },
-            ],
+            routingTypes: {
+              [RoutingType.CLASSIC]: {},
+              [RoutingType.DUTCH_LIMIT]:
+                {
+                  stdAuctionPeriodSecs: 9999,
+                },
+            },
             alarmEnabled: false,
           },
         },
@@ -695,13 +666,14 @@ describe('ChainConfigManager', () => {
       setChainConfigManager(
         {
           [ChainId.MAINNET]: {
-            routingTypes: [
+            routingTypes: {
+              [RoutingType.CLASSIC]: {},
+              [RoutingType.DUTCH_LIMIT]:
               {
-                routingType: RoutingType.DUTCH_LIMIT,
                 stdAuctionPeriodSecs: 1,
                 largeAuctionPeriodSecs: 9999,
               },
-            ],
+            },
             alarmEnabled: false,
           },
         },
@@ -763,13 +735,14 @@ describe('ChainConfigManager', () => {
         setChainConfigManager(
           {
             [ChainId.MAINNET]: {
-              routingTypes: [
-                {
-                  routingType: routingType,
-                  deadlineBufferSecs: 9999,
-                  skipRFQ: true,
-                },
-              ],
+              routingTypes: {
+                [RoutingType.CLASSIC]: {},
+                [routingType]:
+                  {
+                    deadlineBufferSecs: 9999,
+                    skipRFQ: true,
+                  },
+              },
               alarmEnabled: false,
             },
           },

--- a/test/unit/lib/config/ChainConfigManager.test.ts
+++ b/test/unit/lib/config/ChainConfigManager.test.ts
@@ -207,7 +207,7 @@ describe('ChainConfigManager', () => {
         [ChainId.MAINNET]: {
           routingTypes: [
             {
-              routingType: RoutingType.CLASSIC,
+              routingType: RoutingType.DUTCH_V2,
               stdAuctionPeriodSecs: 99,
             },
             {
@@ -221,7 +221,7 @@ describe('ChainConfigManager', () => {
           alarmEnabled: false,
         },
       });
-      let quoteConfig = ChainConfigManager.getQuoteConfig(ChainId.MAINNET, RoutingType.CLASSIC);
+      let quoteConfig = ChainConfigManager.getQuoteConfig(ChainId.MAINNET, RoutingType.DUTCH_V2);
       expect(quoteConfig.stdAuctionPeriodSecs).toEqual(99);
       quoteConfig = ChainConfigManager.getQuoteConfig(ChainId.MAINNET, RoutingType.DUTCH_LIMIT);
       expect(quoteConfig.stdAuctionPeriodSecs).toEqual(undefined);


### PR DESCRIPTION
Addressing some [PR feedback](https://github.com/Uniswap/unified-routing-api/pull/397).

Changes:
1. Improve interface of `getQuoteConfig` to prevent the need to cast. This is done using generics and indexing into the `RoutingTypeOverrides` using the generic input for the response type.
```
public static getQuoteConfig<T extends RoutingType>(chainId: ChainId, routingType: T): Exclude<RoutingTypeOverrides[T], undefined> {
```
2. `ChainConfigMap` now uses a map for the `routingType` parameter keyed off of the different `RoutingType`s. This ensures uniqueness (no duplication) of the routing type per chain.
3. Route dependency check now throws an error if there are missing dependents (previously it would add the dependencies).