### PR TITLE
fix: undo `4e6e37fbaeb5842edb367c52ca4c3363f9587754` 

### DIFF
--- a/lib/entities/quote/DutchQuote.ts
+++ b/lib/entities/quote/DutchQuote.ts
@@ -263,8 +263,8 @@ export abstract class DutchQuote<T extends DutchQuoteRequest> implements IQuote 
   // Calculates the gas adjustment for the given quote if processed through UniswapX
   // Swap gas adjustments are paid by the filler in the process of filling a trade
   // and should be applied to endAmounts
-  static applyGasAdjustment(amounts: Amounts, classicQuote: ClassicQuote, adjustmentBps?: number): Amounts {
-    const gasAdjustment = DutchQuote.getGasAdjustment(classicQuote, adjustmentBps);
+  static applyGasAdjustment(amounts: Amounts, classicQuote: ClassicQuote): Amounts {
+    const gasAdjustment = DutchQuote.getGasAdjustment(classicQuote);
     if (gasAdjustment.eq(0)) return amounts;
     return DutchQuote.getGasAdjustedAmounts(
       amounts,
@@ -358,7 +358,7 @@ export abstract class DutchQuote<T extends DutchQuoteRequest> implements IQuote 
   }
 
   // Returns the number of gas units extra required to execute this quote through UniswapX
-  static getGasAdjustment(classicQuote: ClassicQuote, adjustmentBps?: number): BigNumber {
+  static getGasAdjustment(classicQuote: ClassicQuote): BigNumber {
     let result = BigNumber.from(0);
 
     // fill contract must unwrap WETH output tokens
@@ -366,11 +366,7 @@ export abstract class DutchQuote<T extends DutchQuoteRequest> implements IQuote 
       result = result.add(WETH_UNWRAP_GAS);
     }
 
-    result.add(UNISWAPX_BASE_GAS);
-    if(adjustmentBps) {
-      result = result.mul(BPS + adjustmentBps).div(BPS);
-    }
-    return result;
+    return result.add(UNISWAPX_BASE_GAS);
   }
 }
 

--- a/lib/entities/quote/DutchQuoteFactory.ts
+++ b/lib/entities/quote/DutchQuoteFactory.ts
@@ -125,8 +125,7 @@ export class DutchQuoteFactory {
 
     const classicAmounts = DutchQuote.applyGasAdjustment(
       { amountIn: classic.amountInGasAdjusted, amountOut: classic.amountOutGasAdjusted },
-      classic,
-      quote.request.config.gasAdjustmentBps
+      classic
     );
     const { amountIn: amountInEnd, amountOut: amountOutEnd } = DutchQuote.applySlippage(classicAmounts, quote.request);
 

--- a/lib/entities/request/DutchV1Request.ts
+++ b/lib/entities/request/DutchV1Request.ts
@@ -16,7 +16,6 @@ export interface DutchConfig {
   auctionPeriodSecs?: number;
   deadlineBufferSecs?: number;
   useSyntheticQuotes: boolean;
-  gasAdjustmentBps?: number;
 }
 
 export interface DutchQuoteRequestInfo extends QuoteRequestInfo {
@@ -31,7 +30,6 @@ export interface DutchConfigJSON {
   auctionPeriodSecs?: number;
   deadlineBufferSecs?: number;
   useSyntheticQuotes?: boolean;
-  gasAdjustmentBps?: number;
 }
 
 export class DutchV1Request implements QuoteRequest {

--- a/lib/entities/request/DutchV2Request.ts
+++ b/lib/entities/request/DutchV2Request.ts
@@ -7,7 +7,6 @@ export interface DutchV2Config {
   swapper: string;
   deadlineBufferSecs?: number;
   useSyntheticQuotes: boolean;
-  gasAdjustmentBps?: number;
 }
 
 export interface DutchV2ConfigJSON extends Omit<DutchV2Config, 'useSyntheticQuotes'> {

--- a/test/unit/entities/DutchV2Quote.test.ts
+++ b/test/unit/entities/DutchV2Quote.test.ts
@@ -56,6 +56,9 @@ describe('DutchV2Quote', () => {
       const order = v2Quote.toOrder();
       const orderJson = order.toJSON();
 
+      console.log(orderJson.outputs);
+      console.log(v2Quote.amountOutGasAndPortionAdjusted.toString());
+
       expect(orderJson.outputs[0].startAmount).toEqual(
         v2Quote.amountOutGasAndPortionAdjusted
           .mul(BPS - V2_OUTPUT_AMOUNT_BUFFER_BPS)


### PR DESCRIPTION
This reverts commit 4e6e37fbaeb5842edb367c52ca4c3363f9587754.

This was an unintended merge that took place because of lack of guardrails that have now been turn on.
Specifically, the bypass setting on the `main` branch. 