### PR TITLE
chore: bump lambda version to pick up new Zora secret

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -217,7 +217,7 @@ export class APIStack extends cdk.Stack {
         sourceMap: true,
       },
       environment: {
-        VERSION: '10',
+        VERSION: '11',
         NODE_OPTIONS: '--enable-source-maps',
         stage: props.stage,
         ...props.envVars,


### PR DESCRIPTION
I forgot to ask someone to add the ZORA JSON RPC URL into secret, before merging. Now I have to bump the lambda version so that the URA pipeline can pick up the new secret. I manually retried the entire URA beta stage, but still it can't find the secret:

<img width="803" alt="Screenshot 2024-05-23 at 9 09 39 AM" src="https://github.com/Uniswap/unified-routing-api/assets/91580504/043788b9-61af-4523-b3cf-507e272706f3">
