### PR TITLE
fix: bump sor to pick up the updated weth address

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/router-sdk": "^1.9.2",
     "@uniswap/sdk-core": "^4.2.0",
-    "@uniswap/smart-order-router": "^3.26.0",
+    "@uniswap/smart-order-router": "^3.33.1",
     "@uniswap/uniswapx-sdk": "2.1.0-beta.4",
     "@uniswap/universal-router-sdk": "^2.1.0",
     "aws-cdk-lib": "2.85.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2113,10 +2113,10 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@uniswap/smart-order-router@^3.26.0":
-  version "3.33.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/smart-order-router/-/smart-order-router-3.33.0.tgz#ac67e8a88cea46f206c3b70f9bad894b16d771b9"
-  integrity sha512-G/4AWEbR8LEKJ/L4+V+irgKn4OG97Wx5dc30XgDxFB2E3rfoPhRIvBYXIcVZ2ct7pGQOq4anwR4u7md62JY+ew==
+"@uniswap/smart-order-router@^3.33.1":
+  version "3.33.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/smart-order-router/-/smart-order-router-3.33.1.tgz#026143b88e7e9c77904f0179cc456801d431e8dc"
+  integrity sha512-w6LaNgsMdsz3M+DX98M3PzosHg1nn2mIH/1uXVydNhYG9XyIRLS71x/75mx/jfp1MCoqw/OernLE2cMRq5YQUg==
   dependencies:
     "@eth-optimism/sdk" "^3.2.2"
     "@types/brotli" "^1.3.4"


### PR DESCRIPTION
URA pipeline is failing due to blast integ-tests. WETH address has been updated from 0x4200000000000000000000000000000000000006 to 0x4200000000000000000000000000000000000004. This change is in SOR, so that URA needs to bump SOR.