### PR TITLE
fix: bump lambda version to pick up new zksync secret

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -217,7 +217,7 @@ export class APIStack extends cdk.Stack {
         sourceMap: true,
       },
       environment: {
-        VERSION: '11',
+        VERSION: '12',
         NODE_OPTIONS: '--enable-source-maps',
         stage: props.stage,
         ...props.envVars,


### PR DESCRIPTION
Secret `RPC_324` was created before merging https://github.com/Uniswap/unified-routing-api/pull/428, but it still didn't get picked up. I think we have to manually bump the quote lambda version to be able to pick it up.